### PR TITLE
Feature dev deps refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,18 @@ branches:
   only:
     - master
 
+env:
+  matrix:
+    - NPM_3=true
+    - NPM_3=false
+
 before_install:
   # GUI for real browsers.
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+
+  # Potentially update to npm 3
+  - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
 
 script:
   - npm run builder:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 
   # Potentially update to npm 3
   - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
+  - npm --version
 
 script:
   - npm run builder:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
   # Potentially update to npm 3
   - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
-  - npm --version
 
 script:
+  - npm --version
   - npm run builder:check

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+## Current
+
+* Support new `ARCHETYPE` + `ARCHETYPE-dev` architecture for better NPM 2 + 3
+  `devDependencies` support.
+* Deprecate `builder install` workflow. #16
+
 ## 2.0.1
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ To start using builder, install and save `builder` and any archetypes you
 intend to use. We'll use the [builder-react-component][] archetype as an
 example.
 
+**Note**: Most archetypes have an `ARCHTEYPE` package and parallel
+`ARCHETYPE-dev` NPM package. The `ARCHETYPE` package contains _almost_
+everything needed for the archtype (prod dependencies, scripts, etc.) except
+for the `devDependencies` which the latter `ARCHETYPE-dev` package is solely
+responsible for bringing in.
+
 #### Global Install
 
 For ease of use, one option is to globally install `builder` and locally install
@@ -42,6 +48,7 @@ archetypes:
 ```sh
 $ npm install -g builder
 $ npm install --save builder-react-component
+$ npm install --save-dev builder-react-component-dev
 ```
 
 Like a global install of _any_ Node.js meta / task runner tool (e.g., `eslint`,
@@ -60,7 +67,9 @@ To avoid tying yourself to a single, global version of `builder`, the option
 that we endorse is locally installing both `builder` and archetypes:
 
 ```sh
-$ npm install --save builder builder-react-component
+$ npm install --save builder
+$ npm install --save builder-react-component
+$ npm install --save-dev builder-react-component-dev
 ```
 
 However, to call `builder` from the command line you will either need to
@@ -74,7 +83,7 @@ or call the longer `./node_modules/.bin/builder` instead of `builder` from the
 command line.
 
 
-#### Configure, Install
+#### Configuration
 
 After `builder` is available, you can edit `.builderrc` like:
 
@@ -86,15 +95,6 @@ archetypes:
 
 to bind archetypes.
 
-At this point, `builder` can build any production tasks, as only production
-`dependencies` of archetypes are installed. However, if you are in a
-**development** or CI environment, an additional manual step is needed to
-install the `devDependencies` of all the archetypes:
-
-```sh
-$ builder install
-```
-
 ... and from here you are set for `builder`-controlled meta goodness!
 
 #### Builder Commands
@@ -103,12 +103,6 @@ Display help.
 
 ```sh
 $ builder help
-```
-
-Install archetype `devDependencies`.
-
-```sh
-$ builder install
 ```
 
 Run a single `package.json` `scripts` task.

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,12 @@ var log = require("./log");
 var Config = module.exports = function (cfg) {
   this.cfg = this._loadConfig(cfg);
   this.archetypes = this.cfg.archetypes || [];
+
+  // Include the `-dev` packages.
+  this.allArchetypes = this.archetypes.reduce(function (memo, name) {
+    return memo.concat([name, name + "-dev"]);
+  }, []);
+
   // Array of [name, scripts array] pairs.
   this.scripts = this._loadScripts(this.archetypes);
 };
@@ -158,7 +164,7 @@ Object.defineProperties(Config.prototype, {
      * @returns {Array} Archetype bin paths
      */
     get: function () {
-      return _.map(this.archetypes, function (name) {
+      return _.map(this.allArchetypes, function (name) {
         return path.join(process.cwd(), "node_modules", name, "node_modules/.bin");
       });
     }
@@ -171,8 +177,8 @@ Object.defineProperties(Config.prototype, {
      * @returns {Array} Archetype `node_modules` paths
      */
     get: function () {
-      return _.map(this.archetypes, function (name) {
-        return path.join(process.cwd(), "node_modules", name);
+      return _.map(this.allArchetypes, function (name) {
+        return path.join(process.cwd(), "node_modules", name, "node_modules");
       });
     }
   }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -114,6 +114,12 @@ module.exports = {
   /**
    * Install archetypes.
    *
+   * @deprecated https://github.com/FormidableLabs/builder/issues/16
+   *
+   * `devDependencies` should come from an `ARCHETYPE-dev` package now and
+   * not from the `ARCHETYPE/package.json`'s `devDependencies`, obviating the
+   * need for this separate installation step.
+   *
    * @param {Array}     paths       List of paths in which to `npm install`
    * @param {Object}    opts        Shell options
    * @param {Function}  callback    Callback `(err)`

--- a/lib/task.js
+++ b/lib/task.js
@@ -149,6 +149,12 @@ Task.prototype.concurrent = function (callback) {
 /**
  * Install dev dependencies of archetypes.
  *
+ * @deprecated https://github.com/FormidableLabs/builder/issues/16
+ *
+ * `devDependencies` should come from an `ARCHETYPE-dev` package now and
+ * not from the `ARCHETYPE/package.json`'s `devDependencies`, obviating the
+ * need for this separate installation step.
+ *
  * @param   {Function} callback   Callback function `(err)`
  * @returns {void}
  */
@@ -156,6 +162,8 @@ Task.prototype.install = function (callback) {
   var env = this._env.env; // Raw environment object.
   var paths = this._config.archetypeNodePaths;
 
+  log.warn("Deprecation Warning", "Task will be removed soon. " +
+    "Please update ARCHETYPES to have separate dev packages.");
   log.info(this._action, "Install dev dependencies for:" + paths.map(function (p) {
     return "\n * " + chalk.gray(p);
   }).join(""));


### PR DESCRIPTION
### Status

I've got to wire this PR up, the `builder-react-component` one, and then verify the whole soup-to-nuts thing works in `formidable-react-component-boilerplate`. I'm also adding `npm v3` matrix env vars to all Travis Builds along the way -- we should ticket out / implement the same for Victory repos as many of our developers use `npm v3` which Travis doesn't / the rest of us don't which makes for a bumpy ride for some unsuspecting folks.

* `builder-react-component` PR: https://github.com/FormidableLabs/builder-react-component/pull/6

### Summary

Remove `builder install` workflow in favor of a split `ARCHETYPE` / `ARCHETYPE-dev` publishing scheme that eases NPM v3 transition.

* Fixes #17 #15
* Closes #14
* Relates to #16

### Longer Version

NPM v3's insistence on placing dependencies flatly makes things inconsistent / minorly breaks stuff vs. NPM v2. We're deprecating `builder install` workflow and instead having consuming projects do:

```sh
$ npm install --save builder-react-component
$ npm install --save-dev builder-react-component-dev
```

Where `builder-react-component-dev` is separately published and contains only devDependencies for the archetype. This is tougher for us as the creators of archetypes (maintain two packages), but easier for projects that _use_ archetypes and in-the-trenches developers because it means that the devDependencies for their projects from an archetype are **the real deal** installation-wise.

### PR Notes

* Deprecates `builder install`
* Adds npm v3 to Travis
* Adds `ARCHETYPE-dev` paths to builder runtime.
* Updates documentation

/cc @boygirl @exogen @chaseadamsio 