### PR TITLE
Add check for local version for global install

### DIFF
--- a/bin/builder.js
+++ b/bin/builder.js
@@ -1,25 +1,22 @@
 #!/usr/bin/env node
 "use strict";
 
-// Configuration
-var Config = require("../lib/config");
-var config = new Config();
+var resolve = require("resolve");
+var log = require("../lib/log");
+var localBuilder;
 
-// Set up environment
-var Environment = require("../lib/environment");
-var env = new Environment({
-  config: config
-});
+// Try to resolve builder in the current project's root, use global if fails
+try {
+  localBuilder = resolve.sync(
+    "builder", { basedir: process.cwd(), moduleDirectory: "node_modules" }
+  );
+} catch (e) {
+  log.info("proc:info", "Using global builder");
+  require("../index"); // eslint-disable-line global-require
+}
 
-// Infer task to run
-var Task = require("../lib/task");
-var task = new Task({
-  config: config,
-  env: env
-});
+if (localBuilder) {
+  log.info("proc:info", "Using local builder");
+  require(localBuilder); // eslint-disable-line global-require
 
-// Run the task
-task.execute(function (err) {
-  /*eslint-disable no-process-exit*/
-  process.exit(err ? err.code || 1 : 0);
-});
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// Configuration
+var Config = require("./lib/config");
+var config = new Config();
+
+// Set up environment
+var Environment = require("./lib/environment");
+var env = new Environment({
+  config: config
+});
+
+// Infer task to run
+var Task = require("./lib/task");
+var task = new Task({
+  config: config,
+  env: env
+});
+
+// Run the task
+task.execute(function (err) {
+  /*eslint-disable no-process-exit*/
+  process.exit(err ? err.code || 1 : 0);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "builder",
   "version": "2.1.0",
+  "main": "index.js",
   "description": "An NPM-based task runner",
   "repository": {
     "type": "git",
@@ -24,7 +25,8 @@
     "async": "^1.4.2",
     "chalk": "^1.1.1",
     "js-yaml": "^3.4.3",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "resolve": "^1.1.6"
   },
   "devDependencies": {
     "eslint": "^1.7.3",


### PR DESCRIPTION
This PR adds the following:

- Adds a check for local version so that when the package is global it opts for the local version instead.
- Moves the `bin/builder.js` logic to `/builder.js`. 
- Adds an export of `index.js`

### Testing 

- `npm link`ed my working directory of `builder` and installed a version of `builder` from `npm install` and confirmed that it was using the local version.
- Removed the local version and confirmed that it was using the global version

Relates to #10 cc @ryan-roemer @exogen 