### PR TITLE
Add npmv3 sibling archetype package location detection.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,11 @@ var Config = module.exports = function (cfg) {
     return memo.concat([name, name + "-dev"]);
   }, []);
 
+  // State: Is this a "from NPM" installation on v3+?
+  // (State is set on `_loadScripts`)
+  this._isFromNpm = false;
+  this._isNpmV3 = false;
+
   // Array of [name, scripts array] pairs.
   this.scripts = this._loadScripts(this.archetypes);
 };
@@ -67,9 +72,30 @@ Config.prototype._loadConfig = function (cfg) {
  */
 Config.prototype._loadArchetypeScripts = function (name) {
   /*eslint-disable global-require*/
-  var scripts = (require(path.join(
-    process.cwd(), "node_modules", name, "package.json")) || {}).scripts || {};
+  // Scripts can be contained (npm v2) or siblings (npm v3).
+  //
+  // If a package is installed from NPM **and** we're using NPM v3, then the
+  // archetype is a **sibling** not contained in `ROOT/node_modules`.
+  //
+  // Accordingly, we use information from loading `ROOT/package.json` to
+  // heursitically (hackily) determine if these conditions are true.
+  //
+  // https://github.com/FormidableLabs/builder/issues/25
+  var pkg;
+  try {
+    // Contained.
+    pkg = require(path.join(process.cwd(), "node_modules", name, "package.json"));
+  } catch (err) {
+    // NPM-installed **and** v3 is a sibling.
+    if (this._isFromNpm && this._isNpmV3) {
+      pkg = require(path.join(process.cwd(), "..", name, "package.json"));
+    }
+  }
+  if (!pkg) {
+    throw new Error("Unable to find package.json for: " + name);
+  }
 
+  var scripts = (pkg || {}).scripts || {};
   return _(scripts)
     .pairs()
     // Remove `builder:` internal tasks.
@@ -90,7 +116,22 @@ Config.prototype._loadArchetypeScripts = function (name) {
  * @returns {Array}             Array of script objects
  */
 Config.prototype._loadScripts = function (archetypes) {
-  var CWD_SCRIPTS = (require(path.join(process.cwd(), "package.json")) || {}).scripts || {};
+  var CWD_PKG = require(path.join(process.cwd(), "package.json")) || {};
+  var CWD_SCRIPTS = CWD_PKG.scripts || {};
+
+  // HACK: Detect if potential sibling with heuristic if "from npm";
+  this._isFromNpm = !!CWD_PKG._resolved;
+
+  // HACK: Detect if NPM v3 from user agent.
+  var match = (process.env.npm_config_user_agent || "").match(/npm\/([0-9]+)/);
+  if (match && match[1]) {
+    try {
+      // Version 3 or greater.
+      this._isNpmV3 = parseInt(match[1], 10) >= 3;
+    } catch (err) {
+      // pass through.
+    }
+  }
 
   return [["ROOT", CWD_SCRIPTS]].concat(_(archetypes)
     .map(function (name) {


### PR DESCRIPTION
Fixes #25

@david-davidson -- Can you try out:

```js
"builder": "FormidableLabs/builder#bug-archetype-path-npm3"
```

in your sandbox and report back here?

/cc @david-davidson @boygirl @exogen 