### PR TITLE
Change to more permissive sibling dependency inference.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,11 @@ var log = require("./log");
  * @returns {void}
  */
 var Config = module.exports = function (cfg) {
+  log.info("config:environment", JSON.stringify({
+    cwd: process.cwd(),
+    dir: __dirname
+  }));
+
   this.cfg = this._loadConfig(cfg);
   this.archetypes = this.cfg.archetypes || [];
 
@@ -28,10 +33,9 @@ var Config = module.exports = function (cfg) {
     return memo.concat([name, name + "-dev"]);
   }, []);
 
-  // State: Is this a "from NPM" installation on v3+?
+  // State: Information about the installation environment.
   // (State is set on `_loadScripts`)
   this._isFromNpm = false;
-  this._isNpmV3 = false;
 
   // Array of [name, scripts array] pairs.
   this.scripts = this._loadScripts(this.archetypes);
@@ -65,13 +69,15 @@ Config.prototype._loadConfig = function (cfg) {
 };
 
 /**
- * Archetype scripts.
+ * Load a single archetype's package.json.
  *
  * @param   {String} name   Archetype name
  * @returns {Object}        Package.json object
  */
-Config.prototype._loadArchetypeScripts = function (name) {
+Config.prototype._loadArchetypePackage = function (name) {
   /*eslint-disable global-require*/
+  var pkgPath;
+
   // Scripts can be contained (npm v2) or siblings (npm v3).
   //
   // If a package is installed from NPM **and** we're using NPM v3, then the
@@ -81,16 +87,44 @@ Config.prototype._loadArchetypeScripts = function (name) {
   // heursitically (hackily) determine if these conditions are true.
   //
   // https://github.com/FormidableLabs/builder/issues/25
-  var pkg;
   try {
-    // Contained.
-    pkg = require(path.join(process.cwd(), "node_modules", name, "package.json"));
+    // Contained in the "usual place"
+    pkgPath = path.join(process.cwd(), "node_modules", name, "package.json");
+    return require(pkgPath);
   } catch (err) {
-    // NPM-installed **and** v3 is a sibling.
-    if (this._isFromNpm && this._isNpmV3) {
-      pkg = require(path.join(process.cwd(), "..", name, "package.json"));
+    /*eslint-disable no-empty*/
+  }
+
+  if (this._isFromNpm) {
+    try {
+      // NPM-installed (sometimes on v2, always on v3)
+      pkgPath = path.join(process.cwd(), "..", name, "package.json");
+      return require(pkgPath);
+    } catch (err) {
+      /*eslint-disable no-empty*/
     }
   }
+
+  try {
+    // Require resolve it
+    var modPath = require.resolve(name);
+    pkgPath = path.join(modPath, "package.json");
+    return require(pkgPath);
+  } catch (err) {
+    /*eslint-disable no-empty*/
+  }
+
+  return undefined;
+};
+
+/**
+ * Archetype scripts.
+ *
+ * @param   {String} name   Archetype name
+ * @returns {Object}        Package.json scripts object
+ */
+Config.prototype._loadArchetypeScripts = function (name) {
+  var pkg = this._loadArchetypePackage(name);
   if (!pkg) {
     throw new Error("Unable to find package.json for: " + name);
   }
@@ -121,17 +155,6 @@ Config.prototype._loadScripts = function (archetypes) {
 
   // HACK: Detect if potential sibling with heuristic if "from npm";
   this._isFromNpm = !!CWD_PKG._resolved;
-
-  // HACK: Detect if NPM v3 from user agent.
-  var match = (process.env.npm_config_user_agent || "").match(/npm\/([0-9]+)/);
-  if (match && match[1]) {
-    try {
-      // Version 3 or greater.
-      this._isNpmV3 = parseInt(match[1], 10) >= 3;
-    } catch (err) {
-      // pass through.
-    }
-  }
 
   return [["ROOT", CWD_SCRIPTS]].concat(_(archetypes)
     .map(function (name) {


### PR DESCRIPTION
Fixes #30 

* Infer sibiling dependencies as a fallback if installed from NPM at all (v3 or v2)
* Also throw in a `require.resolve` as another fallback method.

/cc @exogen @boygirl 