### PR TITLE
Chore: Use straight require for ARCHETYPE/package.json

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -33,10 +33,6 @@ var Config = module.exports = function (cfg) {
     return memo.concat([name, name + "-dev"]);
   }, []);
 
-  // State: Information about the installation environment.
-  // (State is set on `_loadScripts`)
-  this._isFromNpm = false;
-
   // Array of [name, scripts array] pairs.
   this.scripts = this._loadScripts(this.archetypes);
 };
@@ -69,58 +65,21 @@ Config.prototype._loadConfig = function (cfg) {
 };
 
 /**
- * Load a single archetype's package.json.
- *
- * @param   {String} name   Archetype name
- * @returns {Object}        Package.json object
- */
-Config.prototype._loadArchetypePackage = function (name) {
-  /*eslint-disable global-require*/
-  var pkgPath;
-
-  // Scripts can be contained (npm v2) or siblings (npm v3).
-  //
-  // If a package is installed from NPM **and** we're using NPM v3, then the
-  // archetype is a **sibling** not contained in `ROOT/node_modules`.
-  //
-  // Accordingly, we use information from loading `ROOT/package.json` to
-  // heursitically (hackily) determine if these conditions are true.
-  //
-  // https://github.com/FormidableLabs/builder/issues/25
-  try {
-    // Contained in the "usual place"
-    pkgPath = path.join(process.cwd(), "node_modules", name, "package.json");
-    return require(pkgPath);
-  } catch (err) {
-    /*eslint-disable no-empty*/
-  }
-
-  if (this._isFromNpm) {
-    try {
-      // NPM-installed (sometimes on v2, always on v3)
-      pkgPath = path.join(process.cwd(), "..", name, "package.json");
-      return require(pkgPath);
-    } catch (err) {
-      /*eslint-disable no-empty*/
-    }
-  }
-
-  // TODO: Refactor / rethink `require.resolve()` approach.
-  // https://github.com/FormidableLabs/builder/issues/32
-
-  return undefined;
-};
-
-/**
  * Archetype scripts.
  *
  * @param   {String} name   Archetype name
  * @returns {Object}        Package.json scripts object
  */
 Config.prototype._loadArchetypeScripts = function (name) {
-  var pkg = this._loadArchetypePackage(name);
-  if (!pkg) {
-    throw new Error("Unable to find package.json for: " + name);
+  /*eslint-disable global-require*/
+  var pkg;
+  try {
+    pkg = require(name + "/package.json");
+  } catch (err) {
+    log.error("config:load-archetype-scripts",
+      "Error loading package.json for: " + chalk.gray(name) + " " +
+      (err.message || err.toString()));
+    throw err;
   }
 
   var scripts = (pkg || {}).scripts || {};
@@ -146,9 +105,6 @@ Config.prototype._loadArchetypeScripts = function (name) {
 Config.prototype._loadScripts = function (archetypes) {
   var CWD_PKG = require(path.join(process.cwd(), "package.json")) || {};
   var CWD_SCRIPTS = CWD_PKG.scripts || {};
-
-  // HACK: Detect if potential sibling with heuristic if "from npm";
-  this._isFromNpm = !!CWD_PKG._resolved;
 
   return [["ROOT", CWD_SCRIPTS]].concat(_(archetypes)
     .map(function (name) {


### PR DESCRIPTION
Fixes #32

Way simpler and don't care if sibling dependencies anymore!

/cc @exogen @boygirl 