### PR TITLE
Chore: Add `--retries=NUM` to `builder run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ to bind archetypes.
 
 #### Builder Commands
 
-Display help.
+Display general or command-specific help.
 
 ```sh
 $ builder help
+$ builder help run
 ```
 
 Run a single `package.json` `scripts` task.

--- a/lib/args.js
+++ b/lib/args.js
@@ -19,8 +19,8 @@ var FLAGS = {
   },
 
   run: {
-    retries: {
-      desc: "Number of times to re-run task on non-zero exit (default: `1`)",
+    tries: {
+      desc: "Number of times to attempt a task (default: `1`)",
       types: [Number]
     }
   }

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,0 +1,65 @@
+"use strict";
+
+/**
+ * Argv command flags.
+ */
+var path = require("path");
+var _ = require("lodash");
+var nopt = require("nopt");
+var chalk = require("chalk");
+
+// Option flags.
+var FLAGS = {
+  // Global: Should apply across any action.
+  general: {
+    builderrc: {
+      desc: "Path to builder config file (default: `.builderrc`)",
+      types: [path]
+    }
+  },
+
+  run: {
+    retries: {
+      desc: "Number of times to re-run task on non-zero exit (default: `1`)",
+      types: [Number]
+    }
+  }
+};
+
+// Convert our bespoke flags object into `nopt` options.
+var getOpts = function (obj) {
+  return _.mapValues(obj, function (val) {
+    return val.types;
+  });
+};
+
+/**
+ * Retrieve help.
+ *
+ * @param   {String} flagKey  Key of flags to return or `undefined` for general
+ * @returns {String}          Help string
+ */
+var help = function (flagKey) {
+  var flags = _.isUndefined(flagKey) ? FLAGS.general : FLAGS[flagKey];
+
+  return !flags ? "" : _.map(flags, function (val, key) {
+    return chalk.cyan("--" + key) + ": " + val.desc;
+  }).join("\n\n  ");
+};
+
+// Option parser.
+var createFn = function (opts) {
+  return function (argv) {
+    argv = argv || process.argv;
+
+    return nopt(opts, {}, argv);
+  };
+};
+
+module.exports = _.extend({
+  FLAGS: FLAGS,
+  help: help
+}, _.mapValues(FLAGS, function (val) {
+  // Add in `KEY()` methods.
+  return createFn(getOpts(val));
+}));

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ var path = require("path");
 var _ = require("lodash");
 var yaml = require("js-yaml");
 var chalk = require("chalk");
+var args = require("./args");
 var log = require("./log");
 
 /**
@@ -46,6 +47,13 @@ var Config = module.exports = function (cfg) {
 Config.prototype._loadConfig = function (cfg) {
   cfg = cfg || ".builderrc";
 
+  // Override from command line.
+  var parsed = args.general();
+  if (parsed.builderrc) {
+    cfg = parsed.builderrc;
+  }
+
+  // Load from builderrc.
   if (typeof cfg === "string") {
     try {
       cfg = yaml.safeLoad(fs.readFileSync(cfg, "utf8"));

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var exec = require("child_process").exec;
-var _ = require("lodash");
 var async = require("async");
 var log = require("../lib/log");
 
@@ -104,33 +103,6 @@ module.exports = {
 
     async.map(cmds, function (cmd, cb) {
       tracker.add(run(cmd, opts, cb));
-    }, function (err) {
-      tracker.kill();
-
-      callback(err);
-    });
-  },
-
-  /**
-   * Install archetypes.
-   *
-   * @deprecated https://github.com/FormidableLabs/builder/issues/16
-   *
-   * `devDependencies` should come from an `ARCHETYPE-dev` package now and
-   * not from the `ARCHETYPE/package.json`'s `devDependencies`, obviating the
-   * need for this separate installation step.
-   *
-   * @param {Array}     paths       List of paths in which to `npm install`
-   * @param {Object}    opts        Shell options
-   * @param {Function}  callback    Callback `(err)`
-   * @returns {void}
-   */
-  install: function (paths, opts, callback) {
-    var tracker = new Tracker();
-
-    async.mapSeries(paths, function (nodePath, cb) {
-      log.info("install:npm", nodePath);
-      tracker.add(run("npm install", _.extend({}, opts, { cwd: nodePath }), cb));
     }, function (err) {
       tracker.kill();
 

--- a/lib/task.js
+++ b/lib/task.js
@@ -143,7 +143,7 @@ Task.prototype.run = function (callback) {
 
   // Infer flags, if any.
   var flags = args.run(this.argv);
-  var tries = flags.retries > 0 ? flags.retries : 1;
+  var tries = flags.tries > 0 ? flags.tries : 1;
 
   // Set up task.
   var env = this._env.env; // Raw environment object.
@@ -165,7 +165,7 @@ Task.prototype.run = function (callback) {
         error = err;
         success = !error;
 
-        // Check retries.
+        // Check tries.
         if (error && tries > 0) {
           log.warn(this._action + ":retry", chalk.red(tries) + " tries left for task " +
             this._command + chalk.gray(" - " + task));

--- a/lib/task.js
+++ b/lib/task.js
@@ -2,10 +2,12 @@
 
 var path = require("path");
 var _ = require("lodash");
+var async = require("async");
 var chalk = require("chalk");
-var Environment = require("../lib/environment");
-var runner = require("./runner");
+var args = require("./args");
+var Environment = require("./environment");
 var log = require("./log");
+var runner = require("./runner");
 
 /**
  * Task wrapper.
@@ -24,11 +26,13 @@ var Task = module.exports = function (opts) {
   this._env = opts.env || new Environment();
 
   // Infer parts.
-  var argv = opts.argv || process.argv;
-  this._script = argv[1];
-  this._action = argv[2];
-  this._command = argv[3];
-  this._commands = argv.slice(3);
+  this.argv = opts.argv || process.argv;
+  var parsed = args.general(this.argv);
+  var remain = parsed.argv.remain;
+  this._script = this.argv[1];
+  this._action = remain[0];
+  this._command = remain[1];
+  this._commands = remain.slice(1);
 
   // Validation.
   if (!this._config) {
@@ -103,12 +107,24 @@ Task.prototype.getCommand = function (cmd) {
  */
 Task.prototype.help = function (callback) {
   // Arguments after `help` are archetypes.
-  var archetypes = this._commands;
+  var cmd = this._command;
+
+  var actions = this.ACTIONS.map(function (val) {
+    return val === cmd ? chalk.red(cmd) : val;
+  }).join(", ");
+  var action = cmd ? chalk.red(cmd) : "[action]";
+  var actionFlags = "";
+  if (cmd) {
+    actionFlags = "\n\n" + chalk.green.bold("Flags") + ": " + chalk.red(cmd) + "\n\n  " +
+      args.help(cmd);
+  }
 
   log.info("help",
-    "\n\n" + chalk.green.bold("Usage") + ": \n\n  builder [action] [task]" +
-    "\n\n" + chalk.green.bold("Actions") + ": \n\n  " + this.ACTIONS.join(", ") +
-    "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts(archetypes));
+    "\n\n" + chalk.green.bold("Usage") + ": \n\n  builder " + action + " [flags] [task]" +
+    "\n\n" + chalk.green.bold("Actions") + ": \n\n  " + actions +
+    "\n\n" + chalk.green.bold("Flags") + ": General\n\n  " + args.help() +
+    actionFlags +
+    "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts());
 
   callback();
 };
@@ -120,12 +136,49 @@ Task.prototype.help = function (callback) {
  * @returns {void}
  */
 Task.prototype.run = function (callback) {
+  // `builder run` -> `builder help`
+  if (!this._command) {
+    return this.help(callback);
+  }
+
+  // Infer flags, if any.
+  var flags = args.run(this.argv);
+  var tries = flags.retries > 0 ? flags.retries : 1;
+
+  // Set up task.
   var env = this._env.env; // Raw environment object.
   var task = this.getCommand(this._command);
+  var success = false;
+  var error;
 
   log.info(this._action, this._command + chalk.gray(" - " + task));
 
-  runner.run(task, { env: env }, callback);
+  // Iterate and retry!
+  async.whilst(
+    function () {
+      return !success && tries > 0;
+    },
+    function (cb) {
+      runner.run(task, { env: env }, function (err) {
+        // Manage, update state.
+        tries--;
+        error = err;
+        success = !error;
+
+        // Check retries.
+        if (error && tries > 0) {
+          log.warn(this._action + ":retry", chalk.red(tries) + " tries left for task " +
+            this._command + chalk.gray(" - " + task));
+        }
+
+        // Execute without error.
+        cb();
+      }.bind(this));
+    }.bind(this),
+    function (err) {
+      callback(error || err);
+    }
+  );
 };
 
 /**
@@ -144,31 +197,6 @@ Task.prototype.concurrent = function (callback) {
   }).join(""));
 
   runner.concurrent(tasks, { env: env }, callback);
-};
-
-/**
- * Install dev dependencies of archetypes.
- *
- * @deprecated https://github.com/FormidableLabs/builder/issues/16
- *
- * `devDependencies` should come from an `ARCHETYPE-dev` package now and
- * not from the `ARCHETYPE/package.json`'s `devDependencies`, obviating the
- * need for this separate installation step.
- *
- * @param   {Function} callback   Callback function `(err)`
- * @returns {void}
- */
-Task.prototype.install = function (callback) {
-  var env = this._env.env; // Raw environment object.
-  var paths = this._config.archetypeNodePaths;
-
-  log.warn("Deprecation Warning", "Task will be removed soon. " +
-    "Please update ARCHETYPES to have separate dev packages.");
-  log.info(this._action, "Install dev dependencies for:" + paths.map(function (p) {
-    return "\n * " + chalk.gray(p);
-  }).join(""));
-
-  runner.install(paths, { env: env }, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "async": "^1.4.2",
     "chalk": "^1.1.1",
     "js-yaml": "^3.4.3",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "nopt": "^3.0.6"
   },
   "devDependencies": {
     "eslint": "^1.7.3",


### PR DESCRIPTION
This PR:

Fixes #16
Fixes #37 

* Adds in basic support for arbitrary command flags for builder. Using `nopt` because that's what `npm` uses and our mantra is "just like `npm`" :wink: 
* Adds `builder run --retries=NUM TASK`
* Aliases `builder run` to `builder help` #37 
* Adds `builder help run` specific help with specific flags
* Adds `--builderrc=PATH` global command flag.
* Removes deprecated `builder install` #16

My use case for this is retries for `requirepack` functional tests (where I can't use magellan).

/cc @chaseadamsio @boygirl @exogen 