### PR TITLE
Add --queue, --buffer flags, default options and args tests.

### DIFF
--- a/.eslintrc-server-test
+++ b/.eslintrc-server-test
@@ -1,13 +1,11 @@
 ---
 extends:
-  - "defaults/configurations/walmart/es5-test"
   - "defaults/configurations/walmart/es5-node"
 
 env:
   mocha: true
 
 globals:
-  fetch: false
   expect: false
   sandbox: false
 

--- a/.eslintrc-server-test
+++ b/.eslintrc-server-test
@@ -1,0 +1,16 @@
+---
+extends:
+  - "defaults/configurations/walmart/es5-test"
+  - "defaults/configurations/walmart/es5-node"
+
+env:
+  mocha: true
+
+globals:
+  fetch: false
+  expect: false
+  sandbox: false
+
+rules:
+  no-unused-expressions: 0  # Disable for Chai expression assertions.
+  max-nested-callbacks: 0   # Disable for nested describes.

--- a/.istanbul.server.yml
+++ b/.istanbul.server.yml
@@ -1,0 +1,6 @@
+reporting:
+  dir: coverage/server
+  reports:
+    - lcov
+    - json
+    - text-summary

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,10 @@ before_install:
 
 script:
   - npm --version
-  - npm run builder:check
+  - npm run builder:check-ci
+
+  # Manually send coverage reports to coveralls.
+  # - Aggregate client results
+  # - Single server and func test results
+  - ls  coverage/server/lcov.info | cat
+  - cat coverage/server/lcov.info | node_modules/.bin/coveralls || echo "Coveralls upload failed"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ intend to use. We'll use the [builder-react-component][] archetype as an
 example.
 
 **Note**: Most archetypes have an `ARCHTEYPE` package and parallel
-`ARCHETYPE-dev` NPM package. The `ARCHETYPE` package contains _almost_
+`ARCHETYPE-dev` npm package. The `ARCHETYPE` package contains _almost_
 everything needed for the archtype (prod dependencies, scripts, etc.) except
 for the `devDependencies` which the latter `ARCHETYPE-dev` package is solely
 responsible for bringing in.
@@ -129,17 +129,17 @@ Display general or command-specific help (which shows available specific flags).
 
 ```sh
 $ builder help
-$ builder help ACTION
+$ builder help <action>
 ```
 
-Run `builder help ACTION` for all available options. For a quick overview:
+Run `builder help <action>` for all available options. For a quick overview:
 
 ##### builder run
 
-Run a single task from `script`. Analogous to `npm run TASK`
+Run a single task from `script`. Analogous to `npm run <task>`
 
 ```sh
-$ builder run TASK
+$ builder run <task>
 ```
 
 Flags:
@@ -150,12 +150,12 @@ Flags:
 ##### builder concurrent
 
 Run multiple tasks from `script` concurrently. Roughly analogous to
-`npm run TASK1 | npm run TASK2 | npm run TASK3`, but kills all processes on
+`npm run <task1> | npm run <task2> | npm run <task3>`, but kills all processes on
 first non-zero exit (which makes it suitable for test tasks).
 
 
 ```sh
-$ builder concurrent TASK1 TASK2 TASK3
+$ builder concurrent <task1> <task2> <task3>
 ```
 
 Flags:
@@ -173,8 +173,8 @@ would only execute _once_ if successful.
 ## Tasks
 
 The underlying concept here is that `builder` `script` commands simply _are_
-NPM-friendly `package.json` `script` commands. Pretty much anything that you
-can execute with `npm run FOO` can be executed with `builder run FOO`.
+npm-friendly `package.json` `script` commands. Pretty much anything that you
+can execute with `npm run <task>` can be executed with `builder run <task>`.
 
 Builder can run 1+ tasks based out of `package.json` `scripts`. For a basic
 scenario like:
@@ -386,9 +386,9 @@ the archetype into your project and remove all Builder dependencies:
     * resolve duplicate tasks names
     * revise configuration file paths for the moved files
     * replace instances of `builder run <TASK>` with `npm run <TASK>`
-    * for `builder concurrent <TASK1> <TASK2>` tasks, first install the
+    * for `builder concurrent <task1> <task2>` tasks, first install the
       `concurrently` package and then rewrite to:
-      `concurrent 'npm run <TASK1>' 'npm run <TASK2>'`
+      `concurrent 'npm run <task1>' 'npm run <task2>'`
 
 ... and (with assuredly a few minor hiccups) that's about it! You are
 Builder-free and back to a normal `npm`-controlled project.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Travis Status][trav_img]][trav_site]
+[![Coverage Status][cov_img]][cov_site]
 
 Builder
 =======
@@ -122,27 +123,52 @@ to bind archetypes.
 
 ... and from here you are set for `builder`-controlled meta goodness!
 
-#### Builder Commands
+#### Builder Actions
 
-Display general or command-specific help.
+Display general or command-specific help (which shows available specific flags).
 
 ```sh
 $ builder help
-$ builder help run
+$ builder help ACTION
 ```
 
-Run a single `package.json` `scripts` task.
+Run `builder help ACTION` for all available options. For a quick overview:
+
+##### builder run
+
+Run a single task from `script`. Analogous to `npm run TASK`
 
 ```sh
-$ builder run foo-task
+$ builder run TASK
 ```
 
-Run multiple `package.json` `scripts` tasks.
+Flags:
+
+* `--builderrc`: Path to builder config file (default: `.builderrc`)
+* `--tries`: Number of times to attempt a task (default: `1`)
+
+##### builder concurrent
+
+Run multiple tasks from `script` concurrently. Roughly analogous to
+`npm run TASK1 | npm run TASK2 | npm run TASK3`, but kills all processes on
+first non-zero exit (which makes it suitable for test tasks).
+
 
 ```sh
-$ builder concurrent foo-task bar-task baz-task
+$ builder concurrent TASK1 TASK2 TASK3
 ```
 
+Flags:
+
+* `--builderrc`: Path to builder config file (default: `.builderrc`)
+* `--tries`: Number of times to attempt a task (default: `1`)
+* `--queue`: Number of concurrent processes to run (default: unlimited - `0|null`)
+* `--[no-]buffer`: Buffer output until process end (default: `false`)
+
+Note that `tries` will retry _individual_ tasks that are part of the concurrent
+group, not the group itself. So, if `builder concurrent --tries=3 foo bar baz`
+is run and bar fails twice, then only `bar` would be retried. `foo` and `baz`
+would only execute _once_ if successful.
 
 ## Tasks
 
@@ -383,3 +409,6 @@ things settle down in `v3.x`-on.
 [builder-react-component]: https://github.com/FormidableLabs/builder-react-component
 [trav_img]: https://api.travis-ci.org/FormidableLabs/builder.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/builder
+[cov]: https://coveralls.io
+[cov_img]: https://img.shields.io/coveralls/FormidableLabs/builder.svg
+[cov_site]: https://coveralls.io/r/FormidableLabs/builder

--- a/lib/args.js
+++ b/lib/args.js
@@ -11,7 +11,13 @@ var chalk = require("chalk");
 // Generic flags:
 var FLAG_TRIES = {
   desc: "Number of times to attempt a task (default: `1`)",
-  types: [Number]
+  types: [Number],
+  default: function (val) { return val > 0 ? val : 1; }
+};
+var FLAG_QUEUE = {
+  desc: "Number of concurrent processes to run (default: unlimited - `0|null`)",
+  types: [Number],
+  default: function (val) { return val > 0 ? val : null; }
 };
 
 // Option flags.
@@ -20,7 +26,8 @@ var FLAGS = {
   general: {
     builderrc: {
       desc: "Path to builder config file (default: `.builderrc`)",
-      types: [path]
+      types: [path],
+      default: ".builderrc"
     }
   },
 
@@ -29,7 +36,13 @@ var FLAGS = {
   },
 
   concurrent: {
-    tries: FLAG_TRIES
+    tries: FLAG_TRIES,
+    queue: FLAG_QUEUE,
+    buffer: {
+      desc: "Buffer output until process end (default: `false`)",
+      types: [Boolean],
+      default: false
+    }
   }
 };
 
@@ -55,18 +68,37 @@ var help = function (flagKey) {
 };
 
 // Option parser.
-var createFn = function (opts) {
+var createFn = function (flags) {
+  var opts = getOpts(flags);
+
   return function (argv) {
     argv = argv || process.argv;
 
-    return nopt(opts, {}, argv);
+    // Parse.
+    var parsedOpts = nopt(opts, {}, argv);
+
+    // Inject defaults and mutate parsed object.
+    _.extend(parsedOpts, _.mapValues(flags, function (val, key) {
+      var parsedVal = parsedOpts[key];
+
+      if (_.isFunction(val.default)) {
+        return val.default(parsedVal);
+      }
+
+      return _.isUndefined(parsedVal) ? val.default : parsedVal;
+    }));
+
+    // Camel-case flags.
+    return _.mapKeys(parsedOpts, function (val, key) {
+      return _.camelCase(key);
+    });
   };
 };
 
 module.exports = _.extend({
   FLAGS: FLAGS,
   help: help
-}, _.mapValues(FLAGS, function (val) {
+}, _.mapValues(FLAGS, function (flags) {
   // Add in `KEY()` methods.
-  return createFn(getOpts(val));
+  return createFn(flags);
 }));

--- a/lib/config.js
+++ b/lib/config.js
@@ -81,8 +81,20 @@ Config.prototype._loadConfig = function (cfg) {
 Config.prototype._loadArchetypeScripts = function (name) {
   /*eslint-disable global-require*/
   var pkg;
+
+  // `npm link` makes the normal `require()` thing break. Give ourselves an
+  // environment variable to make imports more permissive.
+  if (process.env.LOCAL_DEV) {
+    try {
+      pkg = require(path.join(process.cwd(), "node_modules", name, "package.json"));
+    } catch (err) {
+      /*eslint-disable no-empty*/
+      // Pass through error
+    }
+  }
+
   try {
-    pkg = require(name + "/package.json");
+    pkg = pkg || require(name + "/package.json");
   } catch (err) {
     log.error("config:load-archetype-scripts",
       "Error loading package.json for: " + chalk.gray(name) + " " +
@@ -148,6 +160,8 @@ Config.prototype.displayScripts = function (archetypes) {
       // Hack in a low-occuring string to prioritize "special" `:` names
       return (name.indexOf(":") > -1 ? "0000" : "") + name;
     })
+    // Filter to unique keys and we're in order (`true`)
+    .unique(true)
     .value();
 
   // Then, map in order to scripts.
@@ -205,4 +219,3 @@ Object.defineProperties(Config.prototype, {
     }
   }
 });
-

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,21 +12,34 @@ var log = require("../lib/log");
  *
  * @param {String}    cmd       Shell command
  * @param {Object}    shOpts    Shell options
+ * @param {Object}    opts      Runner options
  * @param {Function}  callback  Callback `(err)`
  * @returns {Object}            Child process object
  */
-var run = function (cmd, shOpts, callback) {
+var run = function (cmd, shOpts, opts, callback) {
+  // Check if buffered output or piped.
+  var buffer = opts.buffer;
+
   log.info("proc:start", cmd);
-  var proc = exec(cmd, shOpts, function (err) {
+  var proc = exec(cmd, shOpts, function (err, stdout, stderr) {
     var code = err ? err.code || 1 : 0;
     var level = code === 0 ? "info" : "warn";
+
+    // Write out buffered output.
+    if (buffer) {
+      process.stdout.write(stdout);
+      process.stderr.write(stderr);
+    }
 
     log[level]("proc:end:" + code, cmd);
     callback(err);
   });
 
-  proc.stdout.pipe(process.stdout, { end: false });
-  proc.stderr.pipe(process.stderr, { end: false });
+  // Concurrent / "whenever" output.
+  if (!buffer) {
+    proc.stdout.pipe(process.stdout, { end: false });
+    proc.stderr.pipe(process.stderr, { end: false });
+  }
 
   return proc;
 };
@@ -42,10 +55,10 @@ var run = function (cmd, shOpts, callback) {
  */
 var retry = function (cmd, shOpts, opts, callback) {
   // Expand options.
-  var tries = opts.tries > 0 ? opts.tries : 1;
   var tracker = opts.tracker;
 
   // State.
+  var tries = opts.tries;
   var success = false;
   var error;
 
@@ -55,7 +68,7 @@ var retry = function (cmd, shOpts, opts, callback) {
       return !success && tries > 0;
     },
     function (cb) {
-      var proc = run(cmd, shOpts, function (err) {
+      var proc = run(cmd, shOpts, opts, function (err) {
         // Manage, update state.
         tries--;
         error = err;
@@ -156,8 +169,15 @@ module.exports = {
    */
   concurrent: function (cmds, shOpts, opts, callback) {
     var tracker = new Tracker();
+    var queue = opts.queue;
 
-    async.map(cmds, function (cmd, cb) {
+    // Get mapper (queue vs. non-queue)
+    var map = queue ?
+      async.mapLimit.bind(async, cmds, queue) :
+      async.map.bind(async, cmds);
+
+    log.info("concurrent", "Starting with queue size: " + chalk.magenta(queue || "unlimited"));
+    map(function (cmd, cb) {
       retry(cmd, shOpts, _.extend({ tracker: tracker }, opts), cb);
     }, function (err) {
       tracker.kill();

--- a/lib/task.js
+++ b/lib/task.js
@@ -142,11 +142,12 @@ Task.prototype.run = function (callback) {
 
   var env = this._env.env; // Raw environment object.
   var task = this.getCommand(this._command);
-  var flags = args.run(this.argv);
+  var flags = args.concurrent(this.argv);
+  var opts = _.extend({}, flags);
 
   log.info(this._action, this._command + chalk.gray(" - " + task));
 
-  runner.run(task, { env: env }, { tries: flags.tries }, callback);
+  runner.run(task, { env: env }, opts, callback);
 };
 
 /**
@@ -160,12 +161,13 @@ Task.prototype.concurrent = function (callback) {
   var cmds = this._commands;
   var tasks = cmds.map(this.getCommand.bind(this));
   var flags = args.concurrent(this.argv);
+  var opts = _.extend({}, flags);
 
   log.info(this._action, cmds.join(", ") + tasks.map(function (t, i) {
     return "\n * " + cmds[i] + chalk.gray(" - " + t);
   }).join(""));
 
-  runner.concurrent(tasks, { env: env }, { tries: flags.tries }, callback);
+  runner.concurrent(tasks, { env: env }, opts, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
   "homepage": "https://github.com/FormidableLabs/builder",
   "scripts": {
     "builder:lint-server": "eslint --color -c .eslintrc-server lib bin",
-    "builder:lint": "npm run builder:lint-server",
-    "builder:check": "npm run builder:lint"
+    "builder:lint-server-test": "eslint --color -c .eslintrc-server-test test",
+    "builder:lint": "npm run builder:lint-server && npm run builder:lint-server-test",
+    "builder:test": "mocha --opts test/server/mocha.opts test/server/spec",
+    "builder:test-cov": "istanbul cover --config .istanbul.server.yml  _mocha -- --opts test/server/mocha.opts test/server/spec",
+    "builder:check": "npm run builder:lint && npm run builder:test",
+    "builder:check-ci": "npm run builder:lint && npm run builder:test-cov"
   },
   "bin": {
     "builder": "bin/builder.js"
@@ -28,8 +32,14 @@
     "nopt": "^3.0.6"
   },
   "devDependencies": {
+    "chai": "^3.4.1",
+    "coveralls": "^2.11.4",
     "eslint": "^1.7.3",
     "eslint-config-defaults": "^7.0.1",
-    "eslint-plugin-filenames": "^0.1.2"
+    "eslint-plugin-filenames": "^0.1.2",
+    "istanbul": "^0.4.1",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/server/mocha.opts
+++ b/test/server/mocha.opts
@@ -1,0 +1,2 @@
+--require test/server/setup.js
+--recursive

--- a/test/server/setup.js
+++ b/test/server/setup.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * Test setup for server-side tests.
+ */
+var chai = require("chai");
+var sinonChai = require("sinon-chai");
+
+// Add chai plugins.
+chai.use(sinonChai);
+
+// Add test lib globals.
+global.expect = chai.expect;

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * Base server unit test initialization / global before/after's.
+ *
+ * This file should be `require`'ed by all other test files.
+ *
+ * **Note**: Because there is a global sandbox server unit tests should always
+ * be run in a separate process from other types of tests.
+ */
+var sinon = require("sinon");
+
+before(function () {
+  // Set test environment
+  process.env.NODE_ENV = process.env.NODE_ENV || "test";
+});
+
+beforeEach(function () {
+  global.sandbox = sinon.sandbox.create({
+    useFakeTimers: true
+  });
+});
+
+afterEach(function () {
+  global.sandbox.restore();
+});

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -1,0 +1,188 @@
+"use strict";
+
+var path = require("path");
+var _ = require("lodash");
+var args = require("../../../../lib/args");
+
+require("../base.spec");
+
+// Helper: Remove `argv` from nopts parsed object.
+var _flags = function (parsed) {
+  return _.omit(parsed, "argv");
+};
+
+describe("lib/args", function () {
+  var argv;
+
+  beforeEach(function () {
+    argv = ["node", "builder"];
+  });
+
+  describe("help", function () {
+    // TODO: `args.help()` tests.
+    // https://github.com/FormidableLabs/builder/issues/41
+    it("displays help for 'help'");
+    it("displays help for 'run'");
+    it("displays help for 'concurrent'");
+  });
+
+  describe("general", function () {
+
+    it("handles defaults for general flags", function () {
+      expect(_flags(args.general(argv))).to.deep.equal({
+        builderrc: ".builderrc"
+      });
+    });
+
+    it("handles custom paths for --builderrc", function () {
+      // Set to a nonexistent path (note args _doesn't_ check valid path).
+      var dummyPath = path.join(__dirname, "DUMMYRC");
+      argv = argv.concat(["--builderrc=" + dummyPath]);
+
+      expect(_flags(args.general(argv))).to.deep.equal({
+        builderrc: dummyPath
+      });
+    });
+
+    // TODO: Potential future functionality.
+    // https://github.com/FormidableLabs/builder/issues/42
+    it("validates paths for --builderrc");
+
+  });
+
+  describe("run", function () {
+
+    it("handles defaults for run flags", function () {
+      expect(_flags(args.run(argv))).to.deep.equal({
+        tries: 1
+      });
+    });
+
+    it("handles valid --tries", function () {
+      argv = argv.concat(["--tries=2"]);
+      expect(_flags(args.run(argv))).to.deep.equal({
+        tries: 2
+      });
+    });
+
+    it("handles invalid --tries", function () {
+      // Invalid tries default to `1`.
+
+      expect(_flags(args.run(argv.concat(["--tries=-1"])))).to.deep.equal({
+        tries: 1
+      });
+
+      expect(_flags(args.run(argv.concat(["--tries=BAD"])))).to.deep.equal({
+        tries: 1
+      });
+
+      expect(_flags(args.run(argv.concat(["--tries="])))).to.deep.equal({
+        tries: 1
+      });
+    });
+
+  });
+
+  describe("concurrent", function () {
+
+    it("handles defaults for concurrent flags", function () {
+      expect(_flags(args.concurrent(argv))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+    });
+
+    it("handles valid --tries, --queue --buffer", function () {
+      argv = argv.concat(["--tries=2", "--queue=2", "--buffer"]);
+      expect(_flags(args.concurrent(argv))).to.deep.equal({
+        queue: 2,
+        buffer: true,
+        tries: 2
+      });
+    });
+
+    it("handles valid --buffer", function () {
+      expect(_flags(args.concurrent(argv.concat(["--buffer"])))).to.deep.equal({
+        queue: null,
+        buffer: true,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--no-buffer"])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--buffer=false"])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--buffer=true"])))).to.deep.equal({
+        queue: null,
+        buffer: true,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--buffer=1"])))).to.deep.equal({
+        queue: null,
+        buffer: true,
+        tries: 1
+      });
+    });
+
+    it("handles invalid --tries", function () {
+      // Invalid tries default to `1`.
+      expect(_flags(args.concurrent(argv.concat(["--tries=-1"])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--tries=BAD", "--queue=2"])))).to.deep.equal({
+        queue: 2,
+        buffer: false,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--tries="])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+    });
+
+    it("handles invalid --queue", function () {
+      // Invalid queue defaults to `null`.
+      expect(_flags(args.concurrent(argv.concat(["--queue=-1"])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--queue=BAD", "--tries=2"])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 2
+      });
+
+      expect(_flags(args.concurrent(argv.concat(["--queue="])))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+    });
+
+    it("handles multiple flags", function () {
+      var flags = ["--queue=-1", "--tries=BAD", "--no-buffer"];
+      expect(_flags(args.concurrent(argv.concat(flags)))).to.deep.equal({
+        queue: null,
+        buffer: false,
+        tries: 1
+      });
+    });
+  });
+});


### PR DESCRIPTION
* Add --queue=NUM flag to 'concurrent'
* Add --buffer flag to 'concurrent'
* Add default options to flags in 'args'
* Add basic unit tests for 'args' parsing logic
* Add infrastructure for sinon, mocha, chai, karma
* Hook up Travis to coveralls for coverage reports
* Update README docs
* Add 'LOCAL_DEV' env variable option for 'npm link' local development
* BUGFIX: Make displayHelp() show unique tasks.

/cc @chaseadamsio @exogen @aisapatino 