### PR TITLE
BUG: Fix PATH/NODE_PATH resolution order.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,23 +1,33 @@
 History
 =======
 
+## Current
+
+* Fix `PATH` / `NODE_PATH` resolution order to favor project root, then
+  archetypes, then existing environment.
+  [#47](https://github.com/FormidableLabs/builder/issues/47)
+
 ## 2.1.3
 
-* Just use `require()` for archetype package.json loading. #32
+* Just use `require()` for archetype package.json loading.
+  [#32](https://github.com/FormidableLabs/builder/issues/32)
 
 ## 2.1.2
 
-* Allow archetype discovery from siblings for any npm version. #30
+* Allow archetype discovery from siblings for any npm version.
+  [#30](https://github.com/FormidableLabs/builder/issues/30)
 
 ## 2.1.1
 
-* Fix bug with archetype discovery when npm-installed and npm v3. #25
+* Fix bug with archetype discovery when npm-installed and npm v3.
+  [#25](https://github.com/FormidableLabs/builder/issues/25)
 
 ## 2.1.0
 
 * Support new `ARCHETYPE` + `ARCHETYPE-dev` architecture for better NPM 2 + 3
   `devDependencies` support.
-* **DEPRECATION**: Deprecate `builder install` workflow. #16
+* **DEPRECATION**: Deprecate `builder install` workflow.
+  [#16](https://github.com/FormidableLabs/builder/issues/16)
 
 ## 2.0.1
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -46,28 +46,44 @@ var Environment = module.exports = function (opts) {
 /**
  * Update `PATH` variable with CWD, archetype Node binary paths
  *
+ * Resolution order:
+ * 1. `ROOT/node_modules/.bin`
+ * 2. `ROOT/node_modules/ARCHETYPE[1-n]/node_modules/.bin`
+ * 3. existing `PATH`
+ *
  * @param   {Array}   archetypePaths  Archetype `.bin` paths
  * @returns {String}                  `PATH` environment variable
  */
 Environment.prototype.updatePath = function (archetypePaths) {
-  return (this.env.PATH || "")
+  var basePath = (this.env.PATH || "")
     .split(DELIM)
-    .filter(function (x) { return x; }) // Remove empty strings
-    .concat([CWD_BIN].concat(archetypePaths || []))
+    .filter(function (x) { return x; });
+
+  return [CWD_BIN]
+    .concat(archetypePaths || [])
+    .concat(basePath)
     .join(DELIM);
 };
 
 /**
  * Update `NODE_PATH` variable with CWD, archetype paths
  *
+ * Resolution order:
+ * 1. `ROOT/node_modules/`
+ * 2. `ROOT/node_modules/ARCHETYPE[1-n]/node_modules/`
+ * 3. existing `NODE_PATH`
+ *
  * @param   {Array}   archetypeNodePaths  Archetype `node_module` paths
  * @returns {String}                      `NODE_PATH` environment variable
  * @see https://nodejs.org/api/modules.html
  */
 Environment.prototype.updateNodePath = function (archetypeNodePaths) {
-  return (this.env.NODE_PATH || "")
+  var baseNodePath = (this.env.NODE_PATH || "")
     .split(DELIM)
-    .filter(function (x) { return x; }) // Remove empty strings
-    .concat([CWD_NODE_PATH].concat(archetypeNodePaths || []))
+    .filter(function (x) { return x; });
+
+  return [CWD_NODE_PATH]
+    .concat(archetypeNodePaths || [])
+    .concat(baseNodePath)
     .join(DELIM);
 };

--- a/lib/task.js
+++ b/lib/task.js
@@ -142,7 +142,7 @@ Task.prototype.run = function (callback) {
 
   var env = this._env.env; // Raw environment object.
   var task = this.getCommand(this._command);
-  var flags = args.concurrent(this.argv);
+  var flags = args.run(this.argv);
   var opts = _.extend({}, flags);
 
   log.info(this._action, this._command + chalk.gray(" - " + task));


### PR DESCRIPTION
Fixes #47 

We now have a more sensible PATH / NODE_PATH resolution order.

Also:

* Update links on HISTORY
* Minor flags fix for `builder run`

/cc @dandelany @boygirl @exogen @chaseadamsio 

@dandelany @boygirl @exogen -- Can one of you try this out in an erroring Victory repo? Thanks!