### PR TITLE
BUG: Fix help

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -99,7 +99,8 @@ Task.prototype.getCommand = function (cmd) {
  * Help.
  *
  * ```sh
- * $ builder help [ARCHETYPE, ARCHETYPE]
+ * $ builder help <action>
+ * $ builder help <archetype1> <archetype2>
  * ```
  *
  * @param   {Function} callback   Callback function `(err)`

--- a/lib/task.js
+++ b/lib/task.js
@@ -106,25 +106,29 @@ Task.prototype.getCommand = function (cmd) {
  * @returns {void}
  */
 Task.prototype.help = function (callback) {
-  // Arguments after `help` are archetypes.
+  // Arguments after `help` are action OR archetypes.
   var cmd = this._command;
+  var flagsDisplay = chalk.green.bold("Flags");
 
+  // One matching command is an action: `builder help run`
+  var action = _.contains(this.ACTIONS, cmd) ? cmd : null;
+  var actionDisplay = action ? chalk.red(action) : "<action>";
   var actions = this.ACTIONS.map(function (val) {
-    return val === cmd ? chalk.red(cmd) : val;
+    return val === action ? chalk.red(action) : val;
   }).join(", ");
-  var action = cmd ? chalk.red(cmd) : "[action]";
-  var actionFlags = "";
-  if (cmd) {
-    actionFlags = "\n\n" + chalk.green.bold("Flags") + ": " + chalk.red(cmd) + "\n\n  " +
-      args.help(cmd);
-  }
+  var actionFlags = action ?
+    "\n\n" + flagsDisplay + ": " + actionDisplay + "\n\n  " + args.help(cmd) :
+    "";
+
+  // No matched action means all string are archetypes: `builder help <arch1> <arch2>`
+  var archetypes = action ? null : this._commands;
 
   log.info("help",
-    "\n\n" + chalk.green.bold("Usage") + ": \n\n  builder " + action + " <action> <task(s)>" +
+    "\n\n" + chalk.green.bold("Usage") + ": \n\n  builder " + actionDisplay + " <task(s)>" +
     "\n\n" + chalk.green.bold("Actions") + ": \n\n  " + actions +
-    "\n\n" + chalk.green.bold("Flags") + ": General\n\n  " + args.help() +
+    "\n\n" + flagsDisplay + ": General\n\n  " + args.help() +
     actionFlags +
-    "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts());
+    "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts(archetypes));
 
   callback();
 };


### PR DESCRIPTION
Help originally worked like:

```
$ builder help <archetype1> <archetype2>
```

Then I broke things making it:

```
$ builder help <action>
```

Now, with this PR it does the "right thing" with:

```
$ builder help <action>
$ builder help <archetype1> <archetype2>
```

In the `action` case it displays tailored help for that action.

In the `archetype` case it displays only those tasks for that archetype.

/cc @coopy @exogen @boygirl 