### PR TITLE
Add '--setup=<task>' option to run, concurrent, envs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Flags:
 
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 * `--tries`: Number of times to attempt a task (default: `1`)
+* `--setup`: Single task to run for the entirety of <action>.
 
 ##### builder concurrent
 
@@ -173,6 +174,7 @@ Flags:
 
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 * `--tries`: Number of times to attempt a task (default: `1`)
+* `--setup`: Single task to run for the entirety of <action>.
 * `--queue`: Number of concurrent processes to run (default: unlimited - `0|null`)
 * `--[no-]buffer`: Buffer output until process end (default: `false`)
 
@@ -209,6 +211,7 @@ Flags:
 
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 * `--tries`: Number of times to attempt a task (default: `1`)
+* `--setup`: Single task to run for the entirety of <action>.
 * `--queue`: Number of concurrent processes to run (default: unlimited - `0|null`)
 * `--[no-]buffer`: Buffer output until process end (default: `false`)
 * `--envs-path`: Path to JSON env variable array file (default: `null`)

--- a/lib/args.js
+++ b/lib/args.js
@@ -24,6 +24,11 @@ var FLAG_BUFFER = {
   types: [Boolean],
   default: false
 };
+var FLAG_SETUP = {
+  desc: "Single task to run for the entirety of <action>.",
+  types: [String],
+  default: function (val) { return val || null; }
+};
 
 // Option flags.
 var FLAGS = {
@@ -37,17 +42,20 @@ var FLAGS = {
   },
 
   run: {
-    tries: FLAG_TRIES
+    tries: FLAG_TRIES,
+    setup: FLAG_SETUP
   },
 
   concurrent: {
     tries: FLAG_TRIES,
+    setup: FLAG_SETUP,
     queue: FLAG_QUEUE,
     buffer: FLAG_BUFFER
   },
 
   envs: {
     tries: FLAG_TRIES,
+    setup: FLAG_SETUP,
     queue: FLAG_QUEUE,
     buffer: FLAG_BUFFER,
     "envs-path": {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -102,6 +102,22 @@ var retry = function (cmd, shOpts, opts, callback) {
 };
 
 /**
+ * Add and invoke a setup task if present in options.
+ *
+ * @param {String}    setup     Setup task
+ * @param {Object}    shOpts    Shell options
+ * @returns {Object}            Process object or `null`.
+ */
+var addSetup = function (setup, shOpts) {
+  if (!setup) { return null; }
+
+  log.info("setup:start", "Starting setup task: " + setup);
+  return run("builder run " + setup, shOpts, {}, function (err) {
+    log.warn("setup:error", "Setup command exited with error: " + err.message);
+  });
+};
+
+/**
  * Multi-process tracker.
  *
  * @returns {void}
@@ -117,6 +133,8 @@ var Tracker = function Tracker() {
  * @returns {Object}    Child process object
  */
 Tracker.prototype.add = function (proc) {
+  if (!proc) { return proc; }
+
   var self = this;
 
   // Track.
@@ -157,7 +175,13 @@ module.exports = {
    * @returns {Object}            Child process object
    */
   run: function (cmd, shOpts, opts, callback) {
-    return retry(cmd, shOpts, opts, callback);
+    var tracker = new Tracker();
+    tracker.add(addSetup(opts.setup, shOpts));
+
+    return retry(cmd, shOpts, opts, function (err) {
+      tracker.kill();
+      callback(err);
+    });
   },
 
   /**
@@ -172,6 +196,9 @@ module.exports = {
   concurrent: function (cmds, shOpts, opts, callback) {
     var tracker = new Tracker();
     var queue = opts.queue;
+
+    // Add and invoke setup task.
+    tracker.add(addSetup(opts.setup, shOpts));
 
     // Get mapper (queue vs. non-queue)
     var map = queue ?
@@ -200,6 +227,9 @@ module.exports = {
     var tracker = new Tracker();
     var queue = opts.queue;
     var taskEnvs = opts._envs;
+
+    // Add and invoke setup task.
+    tracker.add(addSetup(opts.setup, shOpts));
 
     // Get mapper (queue vs. non-queue)
     var map = queue ?

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -54,14 +54,16 @@ describe("lib/args", function () {
 
     it("handles defaults for run flags", function () {
       expect(_flags(args.run(argv))).to.deep.equal({
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
 
     it("handles valid --tries", function () {
       argv = argv.concat(["--tries=2"]);
       expect(_flags(args.run(argv))).to.deep.equal({
-        tries: 2
+        tries: 2,
+        setup: null
       });
     });
 
@@ -69,15 +71,34 @@ describe("lib/args", function () {
       // Invalid tries default to `1`.
 
       expect(_flags(args.run(argv.concat(["--tries=-1"])))).to.deep.equal({
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.run(argv.concat(["--tries=BAD"])))).to.deep.equal({
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.run(argv.concat(["--tries="])))).to.deep.equal({
-        tries: 1
+        tries: 1,
+        setup: null
+      });
+    });
+
+    it("handles valid --setup", function () {
+      argv = argv.concat(["--setup=foo"]);
+      expect(_flags(args.run(argv))).to.deep.equal({
+        tries: 1,
+        setup: "foo"
+      });
+    });
+
+    it("handles invalid --setup", function () {
+      argv = argv.concat(["--setup="]);
+      expect(_flags(args.run(argv))).to.deep.equal({
+        tries: 1,
+        setup: null
       });
     });
 
@@ -89,7 +110,8 @@ describe("lib/args", function () {
       expect(_flags(args.concurrent(argv))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
 
@@ -98,7 +120,8 @@ describe("lib/args", function () {
       expect(_flags(args.concurrent(argv))).to.deep.equal({
         queue: 2,
         buffer: true,
-        tries: 2
+        tries: 2,
+        setup: null
       });
     });
 
@@ -106,31 +129,36 @@ describe("lib/args", function () {
       expect(_flags(args.concurrent(argv.concat(["--buffer"])))).to.deep.equal({
         queue: null,
         buffer: true,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--no-buffer"])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--buffer=false"])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--buffer=true"])))).to.deep.equal({
         queue: null,
         buffer: true,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--buffer=1"])))).to.deep.equal({
         queue: null,
         buffer: true,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
 
@@ -139,19 +167,22 @@ describe("lib/args", function () {
       expect(_flags(args.concurrent(argv.concat(["--tries=-1"])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--tries=BAD", "--queue=2"])))).to.deep.equal({
         queue: 2,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--tries="])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
 
@@ -160,19 +191,22 @@ describe("lib/args", function () {
       expect(_flags(args.concurrent(argv.concat(["--queue=-1"])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--queue=BAD", "--tries=2"])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 2
+        tries: 2,
+        setup: null
       });
 
       expect(_flags(args.concurrent(argv.concat(["--queue="])))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
 
@@ -181,7 +215,8 @@ describe("lib/args", function () {
       expect(_flags(args.concurrent(argv.concat(flags)))).to.deep.equal({
         queue: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
   });
@@ -195,7 +230,8 @@ describe("lib/args", function () {
         queue: null,
         envsPath: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
 
@@ -207,7 +243,8 @@ describe("lib/args", function () {
         queue: 2,
         envsPath: dummyPath,
         buffer: true,
-        tries: 2
+        tries: 2,
+        setup: null
       });
     });
 
@@ -217,7 +254,8 @@ describe("lib/args", function () {
         queue: null,
         envsPath: null,
         buffer: false,
-        tries: 1
+        tries: 1,
+        setup: null
       });
     });
   });


### PR DESCRIPTION
Fixes #51

Example case for this flag -- starting up a persistent task for running concurrently with other things that share state like:

* A single dev web server
* Sauce connect / tunnels

```sh
$ builder envs --setup=start-sauce-tunnels run-sauce-tests \
 '[ { "ROWDY_SETTINGS":"sauceLabs.IE_8_Windows_2008_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.IE_9_Windows_2008_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.IE_10_Windows_2012_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.safari_7_OS_X_10_9_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.safari_8_OS_X_10_10_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.chrome_43_OS_X_10_10_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.chrome_43_Windows_2012_R2_Desktop" },
    { "ROWDY_SETTINGS":"sauceLabs.firefox_9_Windows_2012_R2_Desktop" },
    { "ROWDY_SETTINGS":"local.firefox" } ]'
```

/cc @chaseadamsio @exogen @boygirl @coopy 