### PR TITLE
Fix merging of process.env in Node 4+

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -228,7 +228,9 @@ module.exports = {
     log.info("envs", "Starting with queue size: " + chalk.magenta(queue || "unlimited"));
     map(function (taskEnv, cb) {
       // Add each specific set of environment variables.
-      var taskShOpts = _.merge({}, shOpts, { env: taskEnv });
+      // Clone `shOpts` to turn `env` into a plain object: in Node 4+
+      // `process.env` is a special object which changes merge behavior.
+      var taskShOpts = _.merge(_.cloneDeep(shOpts), { env: taskEnv });
       var taskOpts = _.extend({ tracker: tracker, taskEnv: taskEnv }, opts);
 
       log.info("envs", "Starting environment " + chalk.magenta(JSON.stringify(taskEnv)) +


### PR DESCRIPTION
`builder envs` did not work on Node 4+ because `_.merge` was behaving differently due to `process.env` no longer being a plain object. This clones `shOpts` (which contains `env`) so that merge works as expected.

I considered `_.toPlainObject(process.env)` in `environment.js` in place of this fix, to fix the problem at its source. That worked, but I was fearful of the implications as Environment explicitly says that `env` is "environment object to mutate" – and using that fix we'd no longer be mutating `process.env` but a copy.

Fixes #63

/cc @ryan-roemer