### PR TITLE
Add higher maxBuffer to 'exec()' options on invocation. 

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,6 +8,20 @@ var chalk = require("chalk");
 var log = require("./log");
 var Tracker = require("./utils/tracker");
 
+// One limitation of `exec()` is that it unconditionally buffers stdout/stderr
+// input (whether piped, listened, or whatever) leading to a `maxBuffer` bug:
+// https://github.com/FormidableLabs/builder/issues/62
+//
+// We set a comfortable margin here to up the number. In the future, we could
+// just go "whole hog" and bump to `Infinity` if needed.
+//
+// Longer term, we can consider whether we want to do what npm does and use
+// `spawn` with manual OS-compatible `sh` vs. `cmd` detection, cobble together
+// our own flags and manage everything so that we can use the much more flexible
+// `spawn` instead of `exec`.
+// https://github.com/FormidableLabs/builder/issues/20
+var MAX_BUFFER = 32 * 1024 * 1024;
+
 /**
  * Run a single task.
  *
@@ -18,6 +32,11 @@ var Tracker = require("./utils/tracker");
  * @returns {Object}            Child process object
  */
 var run = function (cmd, shOpts, opts, callback) {
+  // Update shell options.
+  shOpts = _.extend({
+    maxBuffer: MAX_BUFFER
+  }, shOpts);
+
   // Check if buffered output or piped.
   var buffer = opts.buffer;
 


### PR DESCRIPTION
Fixes #62

/cc @exogen @chaseadamsio @coopy 