### PR TITLE
Feature: Add '--' custom arguments support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ script:
   - npm --version
   - npm run builder:check-ci
 
+  # Also use builder itself to run the check-ci command
+  - node bin/builder.js run builder:check-ci
+
   # Manually send coverage reports to coveralls.
   # - Aggregate client results
   # - Single server and func test results

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ export PATH="${PATH}:./node_modules/.bin"
 or call the longer `./node_modules/.bin/builder` instead of `builder` from the
 command line.
 
-
 #### Configuration
 
 After `builder` is available, you can edit `.builderrc` like:
@@ -218,6 +217,47 @@ Flags:
 * `--[no-]buffer`: Buffer output until process end (default: `false`)
 * `--[no-]bail`: End all processes after the first failure (default: `true`)
 * `--envs-path`: Path to JSON env variable array file (default: `null`)
+
+###### Custom Flags
+
+Just like [`npm run <task> [-- <args>...]`](https://docs.npmjs.com/cli/run-script),
+flags after a ` -- ` token in a builder task or from the command line are passed
+on to the underlying tasks. This is slightly more complicated for builder in
+that composed tasks pass on the flags _all the way down_. So, for tasks like:
+
+```js
+"scripts": {
+  "down": "echo down",
+  "way": "builder run down -- --way",
+  "the": "builder run way -- --the",
+  "all": "builder run the -- --all"
+}
+```
+
+We can run some basics (alone and with a user-added flag):
+
+```sh
+$ builder run down
+down
+
+$ builder run down -- --my-custom-flag
+down --my-custom-flag
+```
+
+If we run the composed commands, the `--` flags are accumulated:
+
+```sh
+$ builder run all
+down --way --the --all
+
+$ builder run all -- --my-custom-flag
+down --way --the --all --my-custom-flag
+```
+
+The rough heuristic here is if we have custom arguments:
+
+1. If a `builder <action>` command, append with ` -- ` to pass through.
+2. If a non-`builder` command, then append without ` -- ` token.
 
 ## Tasks
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -101,6 +101,18 @@ var createFn = function (flags) {
   return function (argv) {
     argv = argv || process.argv;
 
+    // Capture any flags after `--` like `npm run <task> -- <args>` does.
+    // See: https://docs.npmjs.com/cli/run-script#description
+    var customArgs = [];
+    var customIdx = argv.indexOf("--");
+    if (customIdx > -1) {
+      // Update custom args.
+      customArgs = argv.slice(customIdx + 1);
+
+      // Remove custom args from input.
+      argv = argv.slice(0, customIdx);
+    }
+
     // Parse.
     var parsedOpts = nopt(opts, {}, argv);
 
@@ -115,10 +127,12 @@ var createFn = function (flags) {
       return _.isUndefined(parsedVal) ? val.default : parsedVal;
     }));
 
-    // Camel-case flags.
-    return _.mapKeys(parsedOpts, function (val, key) {
-      return _.camelCase(key);
-    });
+    return _(parsedOpts)
+      // Camel-case flags.
+      .mapKeys(function (val, key) { return _.camelCase(key); })
+      // Add in custom flags if found earlier.
+      .merge(customArgs.length > 0 ? { _customArgs: customArgs } : {})
+      .value();
   };
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -5,6 +5,7 @@ var exec = require("child_process").exec;
 var _ = require("lodash");
 var async = require("async");
 var chalk = require("chalk");
+var argvSplit = require("argv-split");
 var log = require("./log");
 var Tracker = require("./utils/tracker");
 
@@ -28,6 +29,42 @@ var cmdStr = function (cmd, opts) {
     (opts.taskEnv ? ", Environment: " + chalk.magenta(JSON.stringify(opts.taskEnv)) : "");
 };
 
+// Helper for merging in custom options.
+var cmdWithCustom = function (cmd, opts) {
+  opts = opts || {};
+  var customArgs = (opts || {})._customArgs || [];
+
+  // Base case: No custom arguments to add.
+  if (customArgs.length === 0) {
+    return cmd;
+  }
+
+  // Scenario: A base command may have `--` already like `foo -- --bar` which
+  // we need to add to. The hard part is the command may alternately be
+  // something perverse like: `foo "totally -- not extra args"` where we need
+  // to add the `--` to.
+  //
+  // This means _parsing_ a full command string, which we've tried to avoid
+  // doing. So, current library of choice is:
+  // - https://github.com/kaelzhang/node-argv-split
+  //
+  // Other working candidates:
+  // - https://github.com/gabrieleds/node-argv (brings in `minimist` too)
+  //
+  // All of these libraries are a bit wonky / incomplete, so we only _detect_
+  // if `--` is pre-existing before appending to the existing command. But,
+  // for safety we don't mutate the original command (besides appending).
+  var parsed = argvSplit(cmd);
+  var haveCustom = parsed.indexOf("--") > 0;
+
+  // Only add the `--` token if _not_ already there and _is_ a builder task.
+  var isBuilderTask = opts._isBuilderTask === true;
+  var addCustomToken = isBuilderTask && !haveCustom;
+
+  // Add in the custom args with/without `--` token.
+  return cmd + (addCustomToken ? " -- " : " ") + customArgs.join(" ");
+};
+
 /**
  * Run a single task.
  *
@@ -38,6 +75,8 @@ var cmdStr = function (cmd, opts) {
  * @returns {Object}            Child process object
  */
 var run = function (cmd, shOpts, opts, callback) {
+  cmd = cmdWithCustom(cmd, opts);
+
   // Update shell options.
   shOpts = _.extend({
     maxBuffer: MAX_BUFFER
@@ -194,6 +233,9 @@ var createFinish = function (shOpts, opts, tracker, callback) {
  * Task runner.
  */
 module.exports = {
+  // Helpers.
+  _cmdWithCustom: cmdWithCustom,
+
   /**
    * Run a single task.
    *

--- a/lib/task.js
+++ b/lib/task.js
@@ -56,20 +56,32 @@ Task.prototype.toString = function () {
 };
 
 /**
+ * Is this task another builder command?
+ *
+ * @param   {String} task   Task
+ * @returns {Boolean}       Is this task a passthrough?
+ */
+Task.prototype.isBuilderTask = function (task) {
+  var builder = path.basename(this._script);
+  var taskParts = task.split(/\s+/);
+  var taskBin = taskParts[0];
+
+  // Note: Assumes a binary script match without `.js` extension.
+  return builder === taskBin;
+};
+
+/**
  * Is this task a simple passthrough to another builder command?
  *
  * @param   {String} task   Task
  * @returns {Boolean}       Is this task a passthrough?
  */
 Task.prototype.isPassthrough = function (task) {
-  var builder = path.basename(this._script);
   var taskParts = task.split(/\s+/);
-  var taskBin = taskParts[0];
   var taskAction = taskParts[1];
   var taskCommand = taskParts[2];
 
-  // Note: Assumes a binary script match without `.js` extension.
-  return builder === taskBin &&
+  return this.isBuilderTask(task) &&
     this._action === taskAction &&
     this._command === taskCommand;
 };
@@ -93,6 +105,19 @@ Task.prototype.getCommand = function (cmd) {
   }
 
   return task;
+};
+
+/**
+ * Merge base options with custom options.
+ *
+ * @param   {String} task   Task
+ * @param   {Object} opts   Custom options
+ * @returns {Object}        Combined options
+ */
+Task.prototype.getOpts = function (task, opts) {
+  return _.extend({
+    _isBuilderTask: this.isBuilderTask(task)
+  }, opts);
 };
 
 /**
@@ -149,7 +174,7 @@ Task.prototype.run = function (callback) {
   var env = this._env.env; // Raw environment object.
   var task = this.getCommand(this._command);
   var flags = args.run(this.argv);
-  var opts = _.extend({}, flags);
+  var opts = this.getOpts(task, flags);
 
   log.info(this._action, this._command + chalk.gray(" - " + task));
 
@@ -167,7 +192,7 @@ Task.prototype.concurrent = function (callback) {
   var cmds = this._commands;
   var tasks = cmds.map(this.getCommand.bind(this));
   var flags = args.concurrent(this.argv);
-  var opts = _.extend({}, flags);
+  var opts = this.getOpts(tasks[0] || "", flags);
 
   log.info(this._action, cmds.join(", ") + tasks.map(function (t, i) {
     return "\n * " + cmds[i] + chalk.gray(" - " + t);
@@ -206,7 +231,7 @@ Task.prototype.envs = function (callback) {
   var env = this._env.env;
   var task = this.getCommand(this._command);
   var flags = args.envs(this.argv);
-  var opts = _.extend({}, flags);
+  var opts = this.getOpts(task, flags);
 
   // Get task environment array.
   var envsStr = this._commands[1];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "builder:lint-server-test": "eslint --color -c .eslintrc-server-test test",
     "builder:lint": "npm run builder:lint-server && npm run builder:lint-server-test",
     "builder:test": "mocha --opts test/server/mocha.opts test/server/spec",
-    "builder:test-cov": "istanbul cover --config .istanbul.server.yml  _mocha -- --opts test/server/mocha.opts test/server/spec",
+    "builder:test-cov": "istanbul cover --config .istanbul.server.yml _mocha -- --opts test/server/mocha.opts test/server/spec",
     "builder:check": "npm run builder:lint && npm run builder:test",
     "builder:check-ci": "npm run builder:lint && npm run builder:test-cov"
   },
@@ -25,6 +25,7 @@
     "builder": "bin/builder.js"
   },
   "dependencies": {
+    "argv-split": "^1.0.0",
     "async": "^1.4.2",
     "chalk": "^1.1.1",
     "js-yaml": "^3.4.3",

--- a/test/server/spec/lib/runner.spec.js
+++ b/test/server/spec/lib/runner.spec.js
@@ -1,0 +1,85 @@
+"use strict";
+
+var runner = require("../../../../lib/runner");
+
+require("../base.spec");
+
+describe("lib/runner", function () {
+
+  describe("#cmdWithCustom", function () {
+    var cmdWithCustom = runner._cmdWithCustom;
+
+    describe("shell command", function () {
+
+      it("handles base cases", function () {
+        expect(cmdWithCustom("foo")).to.equal("foo");
+        expect(cmdWithCustom("foo --before")).to.equal("foo --before");
+        expect(cmdWithCustom("bar", { _customArgs: [] })).to.equal("bar");
+      });
+
+      it("adds custom arguments", function () {
+        expect(cmdWithCustom("foo", { _customArgs: ["--bar"] })).to.equal("foo --bar");
+        expect(cmdWithCustom("foo --before", { _customArgs: ["--bar", "2", "--baz=3"] }))
+          .to.equal("foo --before --bar 2 --baz=3");
+      });
+
+      it("handles quoted --", function () {
+        expect(cmdWithCustom("foo \"-- in quotes\"", { _customArgs: ["--bar"] }))
+          .to.equal("foo \"-- in quotes\" --bar");
+        expect(cmdWithCustom("foo '-- in quotes'", { _customArgs: ["--bar"] }))
+          .to.equal("foo '-- in quotes' --bar");
+        expect(cmdWithCustom("foo '{\"--\": \"in -- json\"}'", { _customArgs: ["--bar"] }))
+          .to.equal("foo '{\"--\": \"in -- json\"}' --bar");
+      });
+
+      it("adds custom arguments with existing custom arguments", function () {
+        expect(cmdWithCustom("foo -- --first", { _customArgs: ["--second"] }))
+          .to.equal("foo -- --first --second");
+        expect(cmdWithCustom("foo --before -- --first", { _customArgs: ["--second"] }))
+          .to.equal("foo --before -- --first --second");
+      });
+    });
+
+    describe("builder", function () {
+
+      it("handles base cases", function () {
+        expect(cmdWithCustom("builder"), { _isBuilderTask: true }).to.equal("builder");
+        expect(cmdWithCustom("builder --before", { _isBuilderTask: true }))
+          .to.equal("builder --before");
+      });
+
+      it("adds custom arguments", function () {
+        expect(cmdWithCustom("builder", { _customArgs: ["--bar"], _isBuilderTask: true }))
+          .to.equal("builder -- --bar");
+
+        // Preserve `--before` _before_ the `--`.
+        expect(cmdWithCustom("builder --before",
+          { _customArgs: ["--bar", "2", "--baz=3"], _isBuilderTask: true }))
+          .to.equal("builder --before -- --bar 2 --baz=3");
+      });
+
+      it("handles quoted --", function () {
+        expect(cmdWithCustom("builder \"-- in quotes\"",
+          { _customArgs: ["--bar"], _isBuilderTask: true }))
+          .to.equal("builder \"-- in quotes\" -- --bar");
+        expect(cmdWithCustom("builder '-- in quotes'",
+          { _customArgs: ["--bar"], _isBuilderTask: true }))
+          .to.equal("builder '-- in quotes' -- --bar");
+        expect(cmdWithCustom("builder '{\"--\": \"in -- json\"}'",
+          { _customArgs: ["--bar"], _isBuilderTask: true }))
+          .to.equal("builder '{\"--\": \"in -- json\"}' -- --bar");
+      });
+
+      it("adds custom arguments with existing custom arguments", function () {
+        expect(cmdWithCustom("builder -- --first",
+          { _customArgs: ["--second"], _isBuilderTask: true }))
+          .to.equal("builder -- --first --second");
+        expect(cmdWithCustom("builder --before -- --first",
+          { _customArgs: ["--second"], _isBuilderTask: true }))
+          .to.equal("builder --before -- --first --second");
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/builder-react-component/issues/27

Also adds a little CI check to have _builder itself_ run the CI test task.

This is **take two** of this PR as the complex scenario is: should I add the ` -- ` to the _next_ underlying task. We now have a resolution of this which is:

1. If a builder task, then _yes_
2. Otherwise _no_

You can see this in action with the builder-react-component where I pass `--help` all the way down to `karma` instead of having it run the test like normal.

```sh
$ formidable-react-component-boilerplate $ builder run test -- --help
[builder:proc:start] Command: builder run npm:test -- --help
[builder:proc:start] Command: builder run test-frontend -- --help
[builder:proc:start] Command: karma start node_modules/builder-react-component/config/karma/karma.conf.js --help
Karma - Spectacular Test Runner for JavaScript.

START - Start the server / do a single run.

Usage:
  /Users/rroemer/scm/fmd/formidable-react-component-boilerplate/node_modules/builder-react-component-dev/node_modules/.bin/karma start [<configFile>] [<options>]

Options:
  --port                <integer> Port where the server is running.                            
... SNIPPED STUFF ...                                  
```

/cc @waynelkh @coopy @chaseadamsio @baer @exogen @boygirl 