### PR TITLE
Add version support and -h|--help flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,19 @@ to bind archetypes.
 Display general or command-specific help (which shows available specific flags).
 
 ```sh
-$ builder help
+$ builder [-h|--help|help]
 $ builder help <action>
+$ builder help <archetype>
 ```
 
-Run `builder help <action>` for all available options. For a quick overview:
+Run `builder help <action>` for all available options. Version information is
+available with:
+
+```sh
+$ builder [-v|--version]
+```
+
+Let's dive a little deeper into the main builder actions:
 
 ##### builder run
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -7,6 +7,7 @@ var path = require("path");
 var _ = require("lodash");
 var nopt = require("nopt");
 var chalk = require("chalk");
+var pkg = require("../package.json");
 
 // Generic flags:
 var FLAG_TRIES = {
@@ -34,6 +35,16 @@ var FLAG_BAIL = {
   types: [Boolean],
   default: true
 };
+var FLAG_HELP = {
+  desc: "Display help and exit",
+  types: [Boolean],
+  default: false
+};
+var FLAG_VERSION = {
+  desc: "Display version and exit",
+  types: [Boolean],
+  default: false
+};
 
 // Option flags.
 var FLAGS = {
@@ -43,7 +54,9 @@ var FLAGS = {
       desc: "Path to builder config file (default: `.builderrc`)",
       types: [path],
       default: ".builderrc"
-    }
+    },
+    help: FLAG_HELP,
+    version: FLAG_VERSION
   },
 
   run: {
@@ -94,6 +107,15 @@ var help = function (flagKey) {
   }).join("\n\n  ");
 };
 
+/**
+ * Retrieve version.
+ *
+ * @returns {String}          Version string
+ */
+var version = function () {
+  return pkg.version;
+};
+
 // Option parser.
 var createFn = function (flags) {
   var opts = getOpts(flags);
@@ -138,7 +160,8 @@ var createFn = function (flags) {
 
 module.exports = _.extend({
   FLAGS: FLAGS,
-  help: help
+  help: help,
+  version: version
 }, _.mapValues(FLAGS, function (flags) {
   // Add in `KEY()` methods.
   return createFn(flags);

--- a/lib/task.js
+++ b/lib/task.js
@@ -38,21 +38,32 @@ var Task = module.exports = function (opts) {
   if (!this._config) {
     throw new Error("Configuration object required");
   }
-  if (!_.contains(this.ACTIONS, this._action)) {
+
+  // Special flags that short circuit.
+  if (parsed.help === true || remain.length === 0) {
+    this._action = "help";
+  } else if (parsed.version === true) {
+    this._action = "version";
+  }
+
+  // Infer action.
+  if (!_.contains(this.ACTIONS.concat(["version"]), this._action)) {
     throw new Error("Invalid action: " + this._action +
       " - Valid actions: " + this.ACTIONS.join(", "));
   }
 };
 
-Task.prototype.ACTIONS = ["help", "run", "concurrent", "envs"];
+Task.prototype.ACTIONS = ["run", "concurrent", "envs", "help"];
 
 Task.prototype.toString = function () {
   var cmd = this._command;
   if (this._action === "concurrent") {
     cmd = this._commands.join(", ");
+  } else if (_.contains(["help", "version"], this._action)) {
+    cmd = null;
   }
 
-  return this._action + " " + cmd;
+  return this._action + (cmd ? " " + cmd : "");
 };
 
 /**
@@ -126,6 +137,8 @@ Task.prototype.getOpts = function (task, opts) {
  * ```sh
  * $ builder help <action>
  * $ builder help <archetype1> <archetype2>
+ * $ builder --help
+ * $ builder -h
  * ```
  *
  * @param   {Function} callback   Callback function `(err)`
@@ -156,6 +169,22 @@ Task.prototype.help = function (callback) {
     actionFlags +
     "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts(archetypes));
 
+  callback();
+};
+
+/**
+ * Version.
+ *
+ * ```sh
+ * $ builder --version
+ * $ builder -v
+ * ```
+ *
+ * @param   {Function} callback   Callback function `(err)`
+ * @returns {void}
+ */
+Task.prototype.version = function (callback) {
+  process.stdout.write(args.version() + "\n");
   callback();
 };
 

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -21,16 +21,19 @@ describe("lib/args", function () {
   describe("help", function () {
     // TODO: `args.help()` tests.
     // https://github.com/FormidableLabs/builder/issues/41
-    it("displays help for 'help'");
+    it("displays help when no arguments");
     it("displays help for 'run'");
     it("displays help for 'concurrent'");
+    it("displays help for 'envs'");
   });
 
   describe("general", function () {
 
     it("handles defaults for general flags", function () {
       expect(_flags(args.general(argv))).to.deep.equal({
-        builderrc: ".builderrc"
+        builderrc: ".builderrc",
+        help: false,
+        version: false
       });
     });
 
@@ -40,7 +43,9 @@ describe("lib/args", function () {
       argv = argv.concat(["--builderrc=" + dummyPath]);
 
       expect(_flags(args.general(argv))).to.deep.equal({
-        builderrc: dummyPath
+        builderrc: dummyPath,
+        help: false,
+        version: false
       });
     });
 


### PR DESCRIPTION
* Make `builder` with no arguments display help. Fixes #61
* Add `-h|--help` flags for help.
* Add `-v|--version` flags for version.

/cc @coopy @baer @zachhale @chaseadamsio @benbayard @boygirl 