### PR TITLE
Add significantly more test coverage and various bug/doc fixes.

### DIFF
--- a/.eslintrc-server-test
+++ b/.eslintrc-server-test
@@ -7,7 +7,6 @@ env:
 
 globals:
   expect: false
-  sandbox: false
 
 rules:
   no-unused-expressions: 0  # Disable for Chai expression assertions.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ $ builder envs <task> --envs-path=<path-to-json-file>
 Examples:
 
 ```sh
-$ builder envs <task> '[{ "FOO": "VAL1" }, { "FOO": "VAL2" }, { "ENV1": "VAL3" }]'
+$ builder envs <task> '[{ "FOO": "VAL1" }, { "FOO": "VAL2" }, { "FOO": "VAL3" }]'
 $ builder envs <task> '[{ "FOO": "VAL1", "BAR": "VAL2" }, { "FOO": "VAL3" }]'
 ```
 

--- a/bin/builder-core.js
+++ b/bin/builder-core.js
@@ -1,28 +1,44 @@
 "use strict";
 
-module.exports = function (callback) {
-  /*eslint-disable global-require*/
+var chalk = require("chalk");
+
+var Config = require("../lib/config");
+var Environment = require("../lib/environment");
+var Task = require("../lib/task");
+var runner = require("../lib/runner");
+var log = require("../lib/log");
+
+/**
+ * Builder runner.
+ *
+ * @param {Object}    [opts]      Options object
+ * @param {Object}    [opts.env]  Environment object to mutate (Default `process.env`)
+ * @param {Array}     [opts.argv] Arguments array (Default: `process.argv`)
+ * @param {Function}  callback    Callback `(err)`
+ * @returns {void}
+ */
+module.exports = function (opts, callback) {
+  callback = arguments.length === 2 ? callback : opts;
+  opts = (arguments.length === 2 ? opts : {}) || {};
+
   // Configuration
-  var Config = require("../lib/config");
   var config = new Config();
 
   // Set up environment
-  var Environment = require("../lib/environment");
   var env = new Environment({
-    config: config
+    config: config,
+    env: opts.env
   });
 
   // Infer task to run
-  var Task = require("../lib/task");
   var task = new Task({
     config: config,
-    env: env
+    env: env,
+    argv: opts.argv,
+    runner: runner
   });
 
   // Run the task
-  var chalk = require("chalk");
-  var log = require("../lib/log");
-
   log.info("builder-core:start:" + process.pid, "Started: " + chalk.gray(task));
   task.execute(function (err) {
     if (err) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,6 +38,14 @@ var Config = module.exports = function (cfg) {
   this.scripts = this._loadScripts(this.archetypes);
 };
 
+// Expose `require()` for testing.
+//
+// Tests often have needs to mock `fs` which Node 4+ `require`-ing won't work
+// with, defeat the internal `require` cache, etc.
+Config.prototype._lazyRequire = function (mod) {
+  return require(mod); // eslint-disable-line global-require
+};
+
 /**
  * Load configuration.
  *
@@ -79,14 +87,13 @@ Config.prototype._loadConfig = function (cfg) {
  * @returns {Object}        Package.json scripts object
  */
 Config.prototype._loadArchetypeScripts = function (name) {
-  /*eslint-disable global-require*/
   var pkg;
 
   // `npm link` makes the normal `require()` thing break. Give ourselves an
   // environment variable to make imports more permissive.
   if (process.env.LOCAL_DEV) {
     try {
-      pkg = require(path.join(process.cwd(), "node_modules", name, "package.json"));
+      pkg = this._lazyRequire(path.join(process.cwd(), "node_modules", name, "package.json"));
     } catch (err) {
       /*eslint-disable no-empty*/
       // Pass through error
@@ -94,7 +101,7 @@ Config.prototype._loadArchetypeScripts = function (name) {
   }
 
   try {
-    pkg = pkg || require(name + "/package.json");
+    pkg = pkg || this._lazyRequire(name + "/package.json");
   } catch (err) {
     log.error("config:load-archetype-scripts",
       "Error loading package.json for: " + chalk.gray(name) + " " +
@@ -123,7 +130,7 @@ Config.prototype._loadArchetypeScripts = function (name) {
  * @returns {Array}             Array of script objects
  */
 Config.prototype._loadScripts = function (archetypes) {
-  var CWD_PKG = require(path.join(process.cwd(), "package.json")) || {};
+  var CWD_PKG = this._lazyRequire(path.join(process.cwd(), "package.json")) || {};
   var CWD_SCRIPTS = CWD_PKG.scripts || {};
 
   return [["ROOT", CWD_SCRIPTS]].concat(_(archetypes)

--- a/lib/log.js
+++ b/lib/log.js
@@ -2,10 +2,6 @@
 
 var chalk = require("chalk");
 
-// TODO(6): Configurable log levels.
-// https://github.com/FormidableLabs/builder/issues/6
-var cons = console;
-
 // Wrap "type".
 var wrapType = function (type) {
   return "[builder" + (type ? ":" + type : "") + "]";
@@ -15,15 +11,21 @@ var wrapType = function (type) {
  * A super-small logger.
  */
 module.exports = {
+  // TODO(6): Configurable log levels.
+  // https://github.com/FormidableLabs/builder/issues/6
+  _logger: function () {
+    return console;
+  },
+
   info: function (type, msg) {
-    cons.log([chalk.green(wrapType(type)), msg].join(" "));
+    this._logger().info([chalk.green(wrapType(type)), msg].join(" "));
   },
 
   warn: function (type, msg) {
-    cons.warn([chalk.yellow(wrapType(type)), msg].join(" "));
+    this._logger().warn([chalk.yellow(wrapType(type)), msg].join(" "));
   },
 
   error: function (type, msg) {
-    cons.error([chalk.red(wrapType(type)), msg].join(" "));
+    this._logger().error([chalk.red(wrapType(type)), msg].join(" "));
   }
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,6 +8,10 @@ var chalk = require("chalk");
 var argvSplit = require("argv-split");
 var log = require("./log");
 var Tracker = require("./utils/tracker");
+var Config = require("./config");
+var Environment = require("./environment");
+var Task = require("./task");
+var runner;
 
 // One limitation of `exec()` is that it unconditionally buffers stdout/stderr
 // input (whether piped, listened, or whatever) leading to a `maxBuffer` bug:
@@ -169,18 +173,40 @@ var retry = function (cmd, shOpts, opts, callback) {
  *
  * @param {String}    setup     Setup task
  * @param {Object}    shOpts    Shell options
- * @returns {Object}            Process object or `null`.
+ * @returns {Object}            Process object or `null` if no setup.
  */
 var addSetup = function (setup, shOpts) {
   if (!setup) { return null; }
 
   var done = _.once(function (code) {
+    code = code || 0;
     var level = code === 0 ? "info" : "error";
     log[level]("setup:end", "Setup command ended with code: " + code);
   });
 
+  // Create a `Task` object specifically for setup.
+  //
+  // **Note**: Could refactor this out to a higher-level `create` method or
+  // something that could be reused by `builder-core.js`
+  var config = new Config();
+  var env = new Environment({
+    config: config,
+    env: shOpts.env
+  });
+  var task = new Task({
+    config: config,
+    env: env,
+    argv: ["node", "builder", "run", setup],
+    runner: runner
+  });
+
   log.info("setup:start", "Starting setup task: " + setup);
-  var proc = run("builder run " + setup, shOpts, {}, done);
+
+  // Task `run` will return the child process, which we pass back here.
+  var proc = task.execute(done);
+  if (!proc) {
+    throw new Error("Must create a trackable setup process object");
+  }
   proc.on("exit", done);
 
   return proc;
@@ -232,7 +258,7 @@ var createFinish = function (shOpts, opts, tracker, callback) {
 /**
  * Task runner.
  */
-module.exports = {
+runner = module.exports = {
   // Helpers.
   _cmdWithCustom: cmdWithCustom,
 
@@ -249,8 +275,15 @@ module.exports = {
     // Add + invoke setup (if any), bind tracker cleanup, and wrap callback.
     var tracker = new Tracker();
     var finish = createFinish(shOpts, opts, tracker, callback);
+    var tries = opts.tries;
 
-    return retry(cmd, shOpts, opts, finish);
+    // If no retries, actually track and return child process object.
+    if (tries === 1) {
+      return tracker.add(run(cmd, shOpts, opts, finish));
+    }
+
+    // Otherwise retry without returning process object.
+    retry(cmd, shOpts, opts, finish);
   },
 
   /**

--- a/lib/task.js
+++ b/lib/task.js
@@ -7,15 +7,15 @@ var chalk = require("chalk");
 var args = require("./args");
 var Environment = require("./environment");
 var log = require("./log");
-var runner = require("./runner");
 
 /**
  * Task wrapper.
  *
  * @param {Object} opts         Options object
  * @param {Object} opts.config  Configuration object
- * @param {Object} opts.env     Environment object to mutate (Default `process.env`)
+ * @param {Object} opts.env     Environment object to mutate (Default `Environment`)
  * @param {Array}  opts.argv    Arguments array (Default: `process.argv`)
+ * @param {Object} opts.runner  Runner object.
  * @returns {void}
  */
 var Task = module.exports = function (opts) {
@@ -24,6 +24,7 @@ var Task = module.exports = function (opts) {
   // Options.
   this._config = opts.config;
   this._env = opts.env || new Environment();
+  this._runner = opts.runner;
 
   // Infer parts.
   this.argv = opts.argv || process.argv;
@@ -37,13 +38,17 @@ var Task = module.exports = function (opts) {
   // Validation.
   if (!this._config) {
     throw new Error("Configuration object required");
+  } else if (!this._runner) {
+    throw new Error("Runner object required");
   }
 
   // Special flags that short circuit.
-  if (parsed.help === true || remain.length === 0) {
+  if (parsed.help === true) {
     this._action = "help";
   } else if (parsed.version === true) {
     this._action = "version";
+  } else if (remain.length === 0) {
+    this._action = "help";
   }
 
   // Infer action.
@@ -207,7 +212,7 @@ Task.prototype.run = function (callback) {
 
   log.info(this._action, this._command + chalk.gray(" - " + task));
 
-  runner.run(task, { env: env }, opts, callback);
+  return this._runner.run(task, { env: env }, opts, callback);
 };
 
 /**
@@ -227,7 +232,7 @@ Task.prototype.concurrent = function (callback) {
     return "\n * " + cmds[i] + chalk.gray(" - " + t);
   }).join(""));
 
-  runner.concurrent(tasks, { env: env }, opts, callback);
+  this._runner.concurrent(tasks, { env: env }, opts, callback);
 };
 
 Task.prototype._parseJson = function (objStr) {
@@ -264,14 +269,18 @@ Task.prototype.envs = function (callback) {
 
   // Get task environment array.
   var envsStr = this._commands[1];
-  if (envsStr) {
-    // Try string on command line first:
-    // $ builder envs <task> '[{ "FOO": "VAL1" }, { "FOO": "VAL2" }]'
-    opts._envs = this._parseJson(envsStr);
-  } else if (opts.envsPath) {
-    // Try JSON file path next:
-    // $ builder envs <task> --envs-path=my-environment-vars.json
-    opts._envs = this._parseJsonFile(opts.envsPath);
+  try {
+    if (envsStr) {
+      // Try string on command line first:
+      // $ builder envs <task> '[{ "FOO": "VAL1" }, { "FOO": "VAL2" }]'
+      opts._envs = this._parseJson(envsStr);
+    } else if (opts.envsPath) {
+      // Try JSON file path next:
+      // $ builder envs <task> --envs-path=my-environment-vars.json
+      opts._envs = this._parseJsonFile(opts.envsPath);
+    }
+  } catch (parseErr) {
+    return callback(parseErr);
   }
 
   // Validation
@@ -287,21 +296,22 @@ Task.prototype.envs = function (callback) {
     return callback(err);
   }
 
-  runner.envs(task, { env: env }, opts, callback);
+  this._runner.envs(task, { env: env }, opts, callback);
 };
 
 /**
  * Execute task or tasks.
  *
  * @param   {Function} callback   Callback function `(err)`
- * @returns {void}
+ * @returns {Object}              Process object for `run` or `null` otherwise / for errors
  */
 Task.prototype.execute = function (callback) {
   // Check task action method exists.
   if (!this[this._action]) {
-    return callback(new Error("Unrecognized action: " + this._action));
+    callback(new Error("Unrecognized action: " + this._action));
+    return null;
   }
 
   // Call action.
-  this[this._action](callback);
+  return this[this._action](callback);
 };

--- a/lib/utils/tracker.js
+++ b/lib/utils/tracker.js
@@ -48,5 +48,6 @@ Tracker.prototype.kill = function (callback) {
   async.map(this.procs, function (proc, cb) {
     // Ignore errors: We want to kill as many procs as we can.
     treeKill(proc.pid, "SIGTERM", function () { cb(); });
+
   }, callback);
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-filenames": "^0.1.2",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",
+    "mock-fs": "^3.7.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   }

--- a/test/server/fixtures/repeat-script.js
+++ b/test/server/fixtures/repeat-script.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/**
+ * A simple script for run testing:
+ *
+ * Usage:
+ *
+ * ```
+ * $ node test/server/repeat-script.js NUM_TIMES MSG EXIT_CODE
+ *
+ * # Zero times = "forever".
+ * $ node test/server/repeat-script.js 0 "Forever"
+ *
+ * # Zero times = "forever".
+ * $ node test/server/repeat-script.js 5 "Bad Exit" 1
+ * ```
+ *
+ * It runs continuously echoing input args every `INTERVAL` ms.
+ */
+var NUM_TIMES = parseInt(process.argv[2] || "5", 10);
+var MSG = process.argv[3] || "EMPTY";
+var EXIT_CODE = parseInt(process.argv[4] || "0", 10);
+var INTERVAL = 5;
+
+var i = 0;
+var log = function () {
+  if (NUM_TIMES !== 0 && i++ > NUM_TIMES) {
+    process.exit(EXIT_CODE); // eslint-disable-line no-process-exit
+  }
+
+  process.stdout.write((NUM_TIMES === 0 ? "" : i + " - ") + MSG + "\n");
+};
+
+setInterval(log, INTERVAL);
+
+process.on("exit", function (code) {
+  process.stdout.write("EXIT - " + MSG + " - " + code);
+});

--- a/test/server/setup.js
+++ b/test/server/setup.js
@@ -3,6 +3,9 @@
 /**
  * Test setup for server-side tests.
  */
+// Start the mock import _first_ to inject mocks into everything.
+require("mock-fs");
+
 var chai = require("chai");
 var sinonChai = require("sinon-chai");
 

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -8,7 +8,24 @@
  * **Note**: Because there is a global sandbox server unit tests should always
  * be run in a separate process from other types of tests.
  */
+var mockFs = require("mock-fs");
+var fs = require("fs");
 var sinon = require("sinon");
+
+var base = module.exports = {
+  // Generic test helpers.
+  sandbox: null,
+  mockFs: null,
+
+  // File stuff
+  // NOTE: Sync methods are OK here because mocked and in-memory.
+  fileRead: function (filePath) {
+    return fs.readFileSync(filePath).toString();
+  },
+  fileExists: function (filePath) {
+    return fs.existsSync(filePath);
+  }
+};
 
 before(function () {
   // Set test environment
@@ -16,11 +33,14 @@ before(function () {
 });
 
 beforeEach(function () {
-  global.sandbox = sinon.sandbox.create({
+  base.mockFs = mockFs;
+  base.mockFs();
+  base.sandbox = sinon.sandbox.create({
     useFakeTimers: true
   });
 });
 
 afterEach(function () {
-  global.sandbox.restore();
+  base.mockFs.restore();
+  base.sandbox.restore();
 });

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -1,0 +1,690 @@
+"use strict";
+
+/**
+ * These are _almost_ functional tests as we're basically invoking the entire
+ * application, just:
+ *
+ * - Mocking filesystem
+ * - Stubbing the logging abstraction to capture output
+ *
+ * Tests _do_ however use real process `exec`'s. This _slightly_ slows things
+ * down, but allows us to have some very real use case scenarios.
+ */
+var path = require("path");
+var chalk = require("chalk");
+
+var pkg = require("../../../../package.json");
+var Config = require("../../../../lib/config");
+var Task = require("../../../../lib/task");
+var log = require("../../../../lib/log");
+var run = require("../../../../bin/builder-core");
+
+var base = require("../base.spec");
+
+// Helpers
+// **Note**: It would be great to just stub stderr, stdout in beforeEach,
+// but then we don't get test output. So, we manually stub with this wrapper.
+var stdioWrap = function (fn) {
+  return function (done) {
+    base.sandbox.stub(process.stdout, "write");
+
+    var _done = function (err) {
+      process.stdout.write.restore();
+      done(err);
+    };
+
+    try {
+      return fn(_done);
+    } catch (err) {
+      return _done(err);
+    }
+  };
+};
+
+describe("bin/builder-core", function () {
+  var logStubs;
+
+  beforeEach(function () {
+    logStubs = {
+      info: base.sandbox.spy(),
+      warn: base.sandbox.spy(),
+      error: base.sandbox.spy()
+    };
+
+    base.sandbox.stub(log, "_logger").returns(logStubs);
+
+    // Skip `require()`-ing at all so we avoid `require` cache issues.
+    base.sandbox.stub(Config.prototype, "_lazyRequire", function (mod) {
+      if (base.fileExists(mod)) {
+        return JSON.parse(base.fileRead(mod));
+      } else if (base.fileExists(path.join("node_modules", mod))) {
+        return JSON.parse(base.fileRead(path.join("node_modules", mod)));
+      }
+    });
+  });
+
+  describe("errors", function () {
+
+    it("errors on invalid action", function () {
+      var callback = base.sandbox.spy();
+
+      try {
+        run({
+          argv: ["node", "builder", "bad-action"]
+        }, callback);
+      } catch (err) {
+        expect(err).to.have.property("message").that.contains("Invalid action: bad-action");
+        expect(callback).to.not.be.called;
+        return;
+      }
+
+      throw new Error("should have already thrown");
+    });
+
+  });
+
+  describe("builder --version", function () {
+
+    it("runs version", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "version");
+
+      run({
+        argv: ["node", "builder", "--version"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.version).to.be.calledOnce;
+        expect(process.stdout.write).to.be.calledWithMatch(pkg.version);
+
+        done();
+      });
+    }));
+
+  });
+
+  describe("builder help", function () {
+
+    it("runs help with no arguments", function (done) {
+      base.sandbox.spy(Task.prototype, "help");
+
+      run({
+        argv: ["node", "builder"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.help).to.be.calledOnce;
+        expect(logStubs.info).to.be.calledWithMatch("builder <action> <task(s)>");
+
+        done();
+      });
+    });
+
+    it("runs help with `builder run` alone", function (done) {
+      base.sandbox.spy(Task.prototype, "help");
+
+      run({
+        argv: ["node", "builder", "run"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.help).to.be.calledOnce;
+        expect(logStubs.info).to.be.calledWithMatch("builder <action> <task(s)>");
+
+        done();
+      });
+    });
+
+    it("runs help with flags", function (done) {
+      base.sandbox.spy(Task.prototype, "help");
+      base.sandbox.spy(Task.prototype, "run");
+
+      run({
+        argv: ["node", "builder", "run", "foo", "--help"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.help).to.be.calledOnce;
+        expect(Task.prototype.run).to.not.be.called;
+        expect(logStubs.info).to.be.calledWithMatch("builder <action> <task(s)>");
+
+        done();
+      });
+    });
+
+    it("runs help for run command", function (done) {
+      base.sandbox.spy(Task.prototype, "help");
+
+      run({
+        argv: ["node", "builder", "help", "run"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.help).to.be.calledOnce;
+        expect(logStubs.info).to.be.calledWithMatch("builder " + chalk.red("run") + " <task(s)>");
+
+        done();
+      });
+    });
+  });
+
+  describe("builder run", function () {
+
+    it("runs a <root>/package.json command", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "bar": "echo BAR_TASK"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "bar"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.be.calledOnce;
+        expect(process.stdout.write).to.be.calledWithMatch("BAR_TASK");
+
+        done();
+      });
+
+    }));
+
+    it("runs an <archetype>/package.json command", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "scripts": {
+                "foo": "echo FOO_TASK"
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "run", "foo"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.be.calledOnce;
+        expect(process.stdout.write).to.be.calledWithMatch("FOO_TASK");
+
+        done();
+      });
+
+    }));
+
+    it("overrides a <archetype> command with a <root> one", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "package.json": JSON.stringify({
+          "scripts": {
+            "foo": "echo ROOT_TASK"
+          }
+        }, null, 2),
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "scripts": {
+                "foo": "echo ARCH_TASK"
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "run", "foo"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.be.calledOnce;
+        expect(process.stdout.write).to.be.calledWithMatch("ROOT_TASK");
+
+        done();
+      });
+
+    }));
+
+    // TODO: This one is going to be... tough.
+    // https://github.com/FormidableLabs/builder/issues/9
+    it("overrides a <archetype> command with a <root> one in a composed <archetype> command");
+
+    it("runs with --setup", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            // *real* fs for script references. (`0` runs forever).
+            "setup": "node test/server/fixtures/repeat-script.js 0 SETUP",
+            "bar": "node test/server/fixtures/repeat-script.js 5 BAR_TASK"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "bar", "--setup=setup"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.have.callCount(2);
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("SETUP").and
+          .to.be.calledWithMatch("BAR_TASK").and
+          .to.be.calledWithMatch("EXIT - BAR_TASK - 0");
+
+        done();
+      });
+
+    }));
+
+    it("handles --setup early 0 exit", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            // *real* fs for script references. (`0` runs forever).
+            "setup": "node test/server/fixtures/repeat-script.js 2 SETUP",
+            "bar": "node test/server/fixtures/repeat-script.js 5 BAR_TASK"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "bar", "--setup=setup"]
+      }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("Setup exited with code: 0");
+
+        expect(Task.prototype.run).to.have.callCount(2);
+        expect(logStubs.error)
+          .to.be.calledWithMatch("run bar").and
+          .to.be.calledWithMatch("Setup exited with code: 0");
+
+        done();
+      });
+
+    }));
+
+    it("handles --setup early 1 exit", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            // *real* fs for script references. (`0` runs forever).
+            "setup": "node test/server/fixtures/repeat-script.js 2 SETUP 1",
+            "bar": "node test/server/fixtures/repeat-script.js 10 BAR_TASK"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "bar", "--setup=setup"]
+      }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("Setup exited with code: 1");
+
+        expect(Task.prototype.run).to.have.callCount(2);
+        expect(logStubs.error)
+          .to.be.calledWithMatch("run bar").and
+          .to.be.calledWithMatch("Setup exited with code: 1");
+
+        done();
+      });
+
+    }));
+
+    it("runs with --tries=2", stdioWrap(function (done) {
+      base.sandbox.stub(process.stderr, "write");
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "foo": "BAD_COMMAND"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "foo", "--tries=2"]
+      }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("Command failed").and
+          .that.contains("BAD_COMMAND");
+
+        expect(Task.prototype.run).to.be.calledOnce;
+        expect(process.stderr.write).to.be.calledWithMatch("BAD_COMMAND");
+        expect(logStubs.warn).to.be.calledWithMatch(chalk.red("1") + " tries left");
+        expect(logStubs.error)
+          .to.be.calledWithMatch("Command failed").and
+          .to.be.calledWithMatch("BAD_COMMAND");
+
+        done();
+      });
+
+    }));
+
+  });
+
+  describe("builder concurrent", function () {
+
+    it("runs <root>/package.json concurrent commands", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "concurrent");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "one": "echo ONE_TASK",
+            "two": "echo TWO_TASK",
+            "three": "echo THREE_TASK"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "concurrent", "one", "two", "three"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.concurrent).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("ONE_TASK").and
+          .to.be.calledWithMatch("TWO_TASK").and
+          .to.be.calledWithMatch("THREE_TASK");
+
+        done();
+      });
+
+    }));
+
+    it("runs <archetype>/package.json concurrent commands", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "concurrent");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "package.json": JSON.stringify({
+          "scripts": {
+            "two": "echo TWO_ROOT_TASK",
+            "three": "echo THREE_ROOT_TASK"
+          }
+        }, null, 2),
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "scripts": {
+                "one": "echo ONE_TASK",
+                "two": "echo TWO_TASK",
+                "three": "echo THREE_TASK"
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "concurrent", "one", "two", "three"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.concurrent).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("ONE_TASK").and
+          .to.be.calledWithMatch("TWO_ROOT_TASK").and
+          .to.be.calledWithMatch("THREE_ROOT_TASK");
+
+        done();
+      });
+
+    }));
+
+    // TODO: Finish outlined tests.
+    // https://github.com/FormidableLabs/builder/issues/9
+    it("runs with --tries=2");
+    it("runs with --setup");
+    it("runs with --queue=1, --bail=false");
+
+  });
+
+  describe("builder envs", function () {
+
+    it("runs <root>/package.json multiple env commands", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", JSON.stringify([
+          { MY_VAR: "hi" },
+          { MY_VAR: "ho" },
+          { MY_VAR: "yo" }
+        ])]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("ROOT hi").and
+          .to.be.calledWithMatch("ROOT ho").and
+          .to.be.calledWithMatch("ROOT yo");
+
+        done();
+      });
+
+    }));
+
+    it("runs <root>/package.json multiple env commands with --buffer", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "--buffer", "echo", JSON.stringify([
+          { MY_VAR: "hi" },
+          { MY_VAR: "ho" },
+          { MY_VAR: "yo" }
+        ])]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("ROOT hi").and
+          .to.be.calledWithMatch("ROOT ho").and
+          .to.be.calledWithMatch("ROOT yo");
+
+        done();
+      });
+
+    }));
+
+    it("runs <archetype>/package.json multiple env commands", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "scripts": {
+                "echo": "echo ARCH " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", JSON.stringify([
+          { MY_VAR: "hi" },
+          { MY_VAR: "ho" },
+          { MY_VAR: "yo" }
+        ])]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("ARCH hi").and
+          .to.be.calledWithMatch("ARCH ho").and
+          .to.be.calledWithMatch("ARCH yo");
+
+        done();
+      });
+
+    }));
+
+    it("overrides <archetype>/package.json multiple env commands", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2),
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "scripts": {
+                "echo": "echo ARCH " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", JSON.stringify([
+          { MY_VAR: "hi" },
+          { MY_VAR: "ho" },
+          { MY_VAR: "yo" }
+        ])]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("ROOT hi").and
+          .to.be.calledWithMatch("ROOT ho").and
+          .to.be.calledWithMatch("ROOT yo");
+
+        done();
+      });
+
+    }));
+
+    it("errors on empty JSON array", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", JSON.stringify([])]
+      }, function (err) {
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(err).to.have.property("message")
+          .that.contains("Empty/null JSON environments array");
+
+        done();
+      });
+
+    }));
+
+    it("errors on empty JSON non-array", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", JSON.stringify({ not: "array" })]
+      }, function (err) {
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(err).to.have.property("message")
+          .that.contains("Non-array JSON environments object");
+
+        done();
+      });
+
+    }));
+
+    it("errors on malformed JSON array", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", "BAD_JSON"]
+      }, function (err) {
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(err).to.have.property("message")
+          .that.contains("Unexpected token");
+
+        expect(logStubs.error)
+          .to.be.calledWithMatch("Failed to load JSON object");
+
+        done();
+      });
+    }));
+
+    it("errors on nonexistent JSON file", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "envs");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "echo ROOT " + (/^win/.test(process.platform) ? "%MY_VAR%" : "$MY_VAR")
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "envs", "echo", "--envs-path=BAD_JSON"]
+      }, function (err) {
+        expect(Task.prototype.envs).to.be.calledOnce;
+        expect(err).to.have.property("message")
+          .that.contains("ENOENT");
+
+        expect(logStubs.error)
+          .to.be.calledWithMatch("Failed to load JSON file");
+
+        done();
+      });
+    }));
+
+    // TODO: Finish outlined tests.
+    // https://github.com/FormidableLabs/builder/issues/9
+    it("runs with --setup");
+    it("runs with --tries=2");
+    it("runs with --queue=1, --bail=false");
+
+  });
+
+});

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -18,15 +18,6 @@ describe("lib/args", function () {
     argv = ["node", "builder"];
   });
 
-  describe("help", function () {
-    // TODO: `args.help()` tests.
-    // https://github.com/FormidableLabs/builder/issues/41
-    it("displays help when no arguments");
-    it("displays help for 'run'");
-    it("displays help for 'concurrent'");
-    it("displays help for 'envs'");
-  });
-
   describe("general", function () {
 
     it("handles defaults for general flags", function () {


### PR DESCRIPTION
Implementation work for #9

* Add comprehensive "almost" functional tests in `builder-core.spec.js` using `mock-fs` and a
  ton of actual usage scenarios.
* Capture JSON parsing errors for `builder envs` better.
* Fix bug wherein `builder --version` displayed help instead of version.
* Refactor `--setup` execution model to resolve and use a `Task` object straight up
  rather than a `builder run <setup-task-name>`.
* Refactor `config.js` and `log.js` to have stubable methods in tests.
* Enhance `builder-core` to take an options argument.
* Fix minor README.md typo.

/cc @chaseadamsio @benbayard @baer @coopy @zachhale