### PR TITLE
Add support for `package.json:config` analogous to `npm`.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## Current
+
+* Add support for `package.json:config` analogous to `npm`.
+  [#89](https://github.com/FormidableLabs/builder/issues/89)
+
 ## 2.6.0
 
 * Fix bug wherein `builder --version` displayed help instead of version.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Flags:
 * `--[no-]bail`: End all processes after the first failure (default: `true`)
 * `--envs-path`: Path to JSON env variable array file (default: `null`)
 
+_Note_: The environments JSON array will overwrite **existing** values in the
+environment.
+
 ###### Custom Flags
 
 Just like [`npm run <task> [-- <args>...]`](https://docs.npmjs.com/cli/run-script),
@@ -323,6 +326,7 @@ The rough heuristic here is if we have custom arguments:
 1. If a `builder <action>` command, append with ` -- ` to pass through.
 2. If a non-`builder` command, then append without ` -- ` token.
 
+
 ## Tasks
 
 The underlying concept here is that `builder` `script` commands simply _are_
@@ -363,6 +367,193 @@ $ builder concurrent foo bar
 With `concurrent`, all tasks continue running until they all complete _or_
 any task exits with a non-zero exit code, in which case all still alive tasks
 are killed and the Builder process exits with the error code.
+
+
+## npm Config
+
+`builder` supports `package.json` `config` properties the same way that `npm`
+does, with slight enhancements in consideration of multiple `package.json`'s
+in play.
+
+### `npm` Config Overview
+
+As a refresher, `npm` utilizes the `config` field of `package.json` to make
+"per-package" environment variables to `scripts` tasks. For example, if you
+have:
+
+```js
+{
+  "config": {
+    "my_name": "Bob"
+  },
+  "scripts": {
+    "get-name": "echo Hello, ${npm_package_config_my_name}."
+  }
+}
+```
+
+and ran:
+
+```sh
+$ npm run get-name
+Hello, Bob.
+```
+
+More documentation about how `npm` does per-package configuration is at:
+
+* https://docs.npmjs.com/files/package.json#config
+* https://docs.npmjs.com/misc/config#per-package-config-settings
+
+
+### Builder Configs
+
+In `builder`, for a single `package.json` this works essentially the same in
+the above example.
+
+```sh
+$ builder run get-name
+Hello, Bob.
+```
+
+However, `builder` has the added complexity of adding in `config` variables
+from archetypes and the environment. So the basic resolution order for a
+config environment variable is:
+
+1. Look to `npm_package_config_<VAR_NAME>=<VAR_VAL>` on command line.
+2. If not set, then use `<root>/package.json:config:<VAR_NAME>` value.
+3. If not set, then use `<archetype>/package.json:config:<VAR_NAME>` value.
+
+So, let's dive in to a slightly more complex example:
+
+```js
+// <archetype>/package.json
+{
+  "config": {
+    "my_name": "ARCH BOB"
+  },
+  "scripts": {
+    "get-name": "echo Hello, ${npm_package_config_my_name}."
+  }
+}
+
+// <root>/package.json
+{
+  "config": {
+    "my_name": "ROOT JANE"
+  }
+}
+```
+
+When we run the `builder` command, the `<root>` value overrides:
+
+```sh
+$ builder run get-name
+Hello, ROOT JANE.
+```
+
+We can inject a command line flag to override even this value:
+
+```sh
+$ npm_package_config_my_name="CLI JOE" builder run get-name
+Hello, CLI JOE.
+```
+
+_Note_ that the ability to override via the process environment is unique
+to `builder` and not available in real `npm`.
+
+### Config Notes
+
+#### Tip - Use String Values
+
+Although `config` properties can be something like:
+
+```js
+"config": {
+  "enabled": true
+}
+```
+
+We strongly recommend that you always set _strings_ like:
+
+```js
+"config": {
+  "enabled": "true"
+}
+```
+
+And deal just with _string values_ in your tasks, and files. The reasoning here
+is that when overriding values from the command line, the values will always
+be strings, which has a potential for messy, hard-to-diagnose bugs if the
+overridden value is not also a string.
+
+#### npmrc Configuration
+
+`npm` has additional functionality for `config` values that are **not**
+presently supported, such as issuing commands like
+`npm config set <pkg-name>:my_name Bill` that store values in `~/.npmrc` and
+then override the `package.json` values at execution time. We _may_ extend
+support for this as well, but not at the present.
+
+#### Command Line Environment Variables
+
+`npm` does **not** support overriding `config` environment variables from the
+actual environment. So doing something in our original example like:
+
+```sh
+$ npm_package_config_my_name=George npm run get-name
+Hello, Bob.
+```
+
+In fact, npm will refuse to even add environment variables starting with
+`npm_package_config` to the `npm run` environment. E.g.
+
+```js
+{
+  "config": {},
+  "scripts": {
+    "get-npm-val": "echo NPM VAR: ${npm_package_config_var}",
+    "get-env-val": "echo ENV VAR: ${env_var}"
+  }
+}
+```
+
+The `npm` config variable doesn't make it through:
+
+```sh
+$ npm_package_config_var=SET npm run get-npm-val
+NPM VAR:
+```
+
+While a normal environment variable will:
+
+```sh
+$ env_var=SET npm run get-env-val
+ENV VAR: SET
+```
+
+By contrast, `builder` _does_ pass through environment variables already
+existing on the command line, and moreover those overrides takes precedence over
+the root and archetype package.json values. Those same examples with `builder`
+show that the environment variables _do_ make it through:
+
+```sh
+$ npm_package_config_var=SET builder run get-npm-val
+NPM VAR: SET
+
+$ env_var=SET builder run get-env-val
+ENV VAR: SET
+```
+
+Things are a little more complex when using with `builder envs`, but the
+rough rule is that the environment JSON array wins when specified, otherwise
+the existing environment is used:
+
+```sh
+$ npm_package_config_var=CLI builder envs get-npm-val --queue=1 \
+  '[{}, {"npm_package_config_var":"This Overrides"}]'
+NPM VAR: CLI
+NPM VAR: This Overrides
+```
 
 ## Archetypes
 
@@ -804,6 +995,8 @@ the archetype into your project and remove all Builder dependencies:
   Remove the `npm:` prefix from any `scripts` tasks and note that you may have
   to manually resolve tasks of the same name within the archetype and also with
   your project.
+* Copy all `ARCHETYPE/package.json:config` variables to your
+  `PROJECT/package.json:config`.
 * Copy all `ARCHETYPE-dev/package.json:dependencies` to your
   `PROJECT/package.json:devDependencies`
   (e.g., from `builder-react-component-dev`)

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,8 +34,12 @@ var Config = module.exports = function (cfg) {
     return memo.concat([name, name + "-dev"]);
   }, []);
 
-  // Array of [name, scripts array] pairs.
-  this.scripts = this._loadScripts(this.archetypes);
+  // Array of [name, package.json object] pairs.
+  var pkgs = this._loadPkgs(this.archetypes);
+
+  // Array of [name, scripts|config array] pairs.
+  this.scripts = this._loadScripts(pkgs);
+  this.configs = this._loadConfigs(pkgs);
 };
 
 // Expose `require()` for testing.
@@ -81,12 +85,12 @@ Config.prototype._loadConfig = function (cfg) {
 };
 
 /**
- * Archetype scripts.
+ * Archetype package.json.
  *
  * @param   {String} name   Archetype name
- * @returns {Object}        Package.json scripts object
+ * @returns {Object}        Package.json object
  */
-Config.prototype._loadArchetypeScripts = function (name) {
+Config.prototype._loadArchetypePkg = function (name) {
   var pkg;
 
   // `npm link` makes the normal `require()` thing break. Give ourselves an
@@ -109,7 +113,42 @@ Config.prototype._loadArchetypeScripts = function (name) {
     throw err;
   }
 
-  var scripts = (pkg || {}).scripts || {};
+  return pkg || {};
+};
+
+/**
+ * Load packages.
+ *
+ * **Note**: We load packages into an _array_ because order of operation matters
+ * and is as follows:
+ * - CWD
+ * - Archetypes in _reverse_ order in `.builderrc`
+ *
+ * @param   {Array} archetypes  Archetype names
+ * @returns {Array}             Array of [name, package.json object] pairs
+ */
+Config.prototype._loadPkgs = function (archetypes) {
+  var CWD_PKG = this._lazyRequire(path.join(process.cwd(), "package.json")) || {};
+
+  return [["ROOT", CWD_PKG]].concat(_(archetypes)
+    .map(function (name) {
+      /*eslint-disable no-invalid-this*/
+      return [name, this._loadArchetypePkg(name)];
+    }, this)
+    .reverse()
+    .value());
+};
+
+/**
+ * Archetype package scripts.
+ *
+ * _Note_: We filter out any `builder:`-prefaced commands.
+ *
+ * @param   {Object} pkg    Archetype package.json object
+ * @returns {Object}        Package.json scripts object
+ */
+Config.prototype._loadArchetypeScripts = function (pkg) {
+  var scripts = pkg.scripts || {};
   return _(scripts)
     .pairs()
     // Remove `builder:` internal tasks.
@@ -121,44 +160,37 @@ Config.prototype._loadArchetypeScripts = function (name) {
 /**
  * Load archetype scripts.
  *
- * **Note**: We load scripts into an _array_ because order of operation matters
- * and is as follows:
- * - CWD
- * - Archetypes in _reverse_ order in `.builderrc`
- *
- * @param   {Array} archetypes  Archetype names
- * @returns {Array}             Array of script objects
+ * @param   {Array} pkgs  Array of [name, package.json object] pairs.
+ * @returns {Array}       Array of script objects
  */
-Config.prototype._loadScripts = function (archetypes) {
-  var CWD_PKG = this._lazyRequire(path.join(process.cwd(), "package.json")) || {};
-  var CWD_SCRIPTS = CWD_PKG.scripts || {};
+Config.prototype._loadScripts = function (pkgs) {
+  return _.map(pkgs, function (pair) {
+    /*eslint-disable no-invalid-this*/
+    var name = pair[0];
+    var pkg = pair[1];
+    var scripts = name === "ROOT" ? pkg.scripts || {} : this._loadArchetypeScripts(pkg);
 
-  return [["ROOT", CWD_SCRIPTS]].concat(_(archetypes)
-    .map(function (name) {
-      /*eslint-disable no-invalid-this*/
-      return [name, this._loadArchetypeScripts(name)];
-    }, this)
-    .reverse()
-    .value());
+    return [name, scripts];
+  }, this);
 };
 
 /**
- * Return display-friendly list of script commands.
+ * Return display-friendly list of package.json fields commands.
  *
+ * @param   {Array} objs        Array of package.json data.
  * @param   {Array} archetypes  Archetype names to filter to (Default: all)
  * @returns {String}            Display string.
  */
-Config.prototype.displayScripts = function (archetypes) {
-  // Get filtered list of scripts.
-  var scripts = this.scripts;
+Config.prototype._displayFields = function (objs, archetypes) {
+  // Get filtered list of fields.
   if ((archetypes || []).length) {
-    scripts = _.filter(scripts, function (pair) {
+    objs = _.filter(objs, function (pair) {
       return _.contains(archetypes, pair[0]);
     });
   }
 
   // First, get all keys.
-  var keys = _(scripts)
+  var keys = _(objs)
     .map(function (pair) {
       return _.keys(pair[1]);
     })
@@ -171,9 +203,9 @@ Config.prototype.displayScripts = function (archetypes) {
     .unique(true)
     .value();
 
-  // Then, map in order to scripts.
+  // Then, map in order.
   return _.map(keys, function (key) {
-    var tasks = _(scripts)
+    var tasks = _(objs)
       .filter(function (pair) { return pair[1][key]; })
       .map(function (pair) {
         return "\n    " + chalk.gray("[" + pair[0] + "]") + " " + pair[1][key];
@@ -183,6 +215,38 @@ Config.prototype.displayScripts = function (archetypes) {
 
     return "\n  " + chalk.cyan(key) + tasks;
   }, this).join("\n");
+};
+
+/**
+ * Return display-friendly list of script commands.
+ *
+ * @param   {Array} archetypes  Archetype names to filter to (Default: all)
+ * @returns {String}            Display string.
+ */
+Config.prototype.displayScripts = function (archetypes) {
+  return this._displayFields(this.scripts, archetypes);
+};
+
+/**
+ * Load archetype configs.
+ *
+ * @param   {Array} pkgs  Array of [name, package.json object] pairs.
+ * @returns {Array}       Array of config objects
+ */
+Config.prototype._loadConfigs = function (pkgs) {
+  return _.map(pkgs, function (pair) {
+    return [pair[0], pair[1].config || {}];
+  });
+};
+
+/**
+ * Return display-friendly list of configs.
+ *
+ * @param   {Array} archetypes  Archetype names to filter to (Default: all)
+ * @returns {String}            Display string.
+ */
+Config.prototype.displayConfigs = function (archetypes) {
+  return this._displayFields(this.configs, archetypes);
 };
 
 /**
@@ -223,6 +287,34 @@ Object.defineProperties(Config.prototype, {
       return _.map(this.allArchetypes, function (name) {
         return path.join(process.cwd(), "node_modules", name, "node_modules");
       });
+    }
+  },
+
+  "pkgConfigs": {
+    /**
+     * Return object of resolved package.json config fields.
+     *
+     * Resolves in order of "root wins", then in reverse archetype order.
+     *
+     * @returns {Object} environment object.
+     */
+    get: function () {
+      var configs = this.configs;
+      var configNames = _(configs)
+        .map(function (pair) { return _.keys(pair[1]); })
+        .flatten()
+        .uniq()
+        .value();
+
+      // Take "first" config value in arrays as "winning" value.
+      return _(configNames)
+        .map(function (name) {
+          return [name, _.find(configs, function (pair) {
+            return _.has(pair[1], name);
+          })[1][name]];
+        })
+        .object()
+        .value();
     }
   }
 });

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -6,6 +6,7 @@
  * We augment the current environment with additional paths to encompass
  * Builder paths.
  */
+var _ = require("lodash");
 var path = require("path");
 
 // OS-agnostic path delimiter.
@@ -38,9 +39,12 @@ var Environment = module.exports = function (opts) {
     throw new Error("Configuration object required");
   }
 
-  // Mutate environment.
+  // Mutate environment paths.
   this.env.PATH = this.updatePath(this.config.archetypePaths);
   this.env.NODE_PATH = this.updateNodePath(this.config.archetypeNodePaths);
+
+  // Add in npm config environment variables.
+  this.updateConfigVars(this.config.pkgConfigs);
 };
 
 /**
@@ -86,4 +90,29 @@ Environment.prototype.updateNodePath = function (archetypeNodePaths) {
     .concat(archetypeNodePaths || [])
     .concat(baseNodePath)
     .join(DELIM);
+};
+
+/**
+ * Update environment with configuration variables from package.json
+ *
+ * **Note**: We only go _one level deep_ for process.env mutations.
+ *
+ * Resolution order:
+ * 1. Existing environment
+ * 2. `ROOT/package.json:config`
+ * 3. `ROOT/node_modules/ARCHETYPE[1-n]/package.json:config`
+ *
+ * @param   {Object}   pkgConfigs  Resolved config variables.
+ * @returns {Object}               Mutated environment variable.
+ */
+Environment.prototype.updateConfigVars = function (pkgConfigs) {
+  _.each(pkgConfigs, function (val, name) {
+    /*eslint-disable no-invalid-this*/
+    var fullName = "npm_package_config_" + name;
+    if (!_.has(this.env, fullName)) {
+      this.env[fullName] = val;
+    }
+  }, this);
+
+  return this.env;
 };

--- a/lib/task.js
+++ b/lib/task.js
@@ -167,11 +167,15 @@ Task.prototype.help = function (callback) {
   // No matched action means all string are archetypes: `builder help <arch1> <arch2>`
   var archetypes = action ? null : this._commands;
 
+  // Display task configs if we have _some_.
+  var taskConfigs = this._config.displayConfigs(archetypes);
+
   log.info("help",
     "\n\n" + chalk.green.bold("Usage") + ": \n\n  builder " + actionDisplay + " <task(s)>" +
     "\n\n" + chalk.green.bold("Actions") + ": \n\n  " + actions +
     "\n\n" + flagsDisplay + ": General\n\n  " + args.help() +
     actionFlags +
+    (taskConfigs ? "\n\n" + chalk.green.bold("Task Configs") + ": \n" + taskConfigs : "") +
     "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts(archetypes));
 
   callback();

--- a/test/server/fixtures/echo.js
+++ b/test/server/fixtures/echo.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * A simple script for run testing:
+ *
+ * Usage:
+ *
+ * ```
+ * $ node echo.js <optional extra message>
+ * ```
+ *
+ * Uses environment variable `npm_package_config_message`, typically set
+ * in `package.json` like:
+ *
+ * ```js
+ * {
+ *   "config": {
+ *     "_test_message": "Hello"
+ *   }
+ * }
+ * ```
+ */
+var msg = process.env.npm_package_config__test_message;
+var extra = process.argv[2] || "";
+var out = typeof msg + " - " + (msg || "EMPTY") + (extra ? " - " + extra : "");
+process.stdout.write(out + "\n");


### PR DESCRIPTION
* Add `config` support for `builder` process execution environment + tests. Fixes #89.
* Add docs with explanation of `npm` and `builder` config implementations.
* Enhance existing tests.
    * Fix many missing `package.json` mock files in tests.
    * Add ignoring `builder:`-prefixed test.
    * Add `builder envs` with `--envs-paths=FILE` test.

/cc @coopy @zachhale @boygirl @benbayard @chaseadamsio @shakefon
