### PR TITLE
Pass `--` custom flags through environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ down --way --the --all --my-custom-flag
 
 The rough heuristic here is if we have custom arguments:
 
-1. If a `builder <action>` command, append with ` -- ` to pass through.
+1. If a `builder <action>` command, pass through using builder-specific
+   environment variables. (Builder uses `_BUILDER_ARGS_CUSTOM_FLAGS`).
 2. If a non-`builder` command, then append without ` -- ` token.
 
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -125,11 +125,11 @@ var createFn = function (flags) {
 
     // Capture any flags after `--` like `npm run <task> -- <args>` does.
     // See: https://docs.npmjs.com/cli/run-script#description
-    var customArgs = [];
+    var customFlags = [];
     var customIdx = argv.indexOf("--");
     if (customIdx > -1) {
       // Update custom args.
-      customArgs = argv.slice(customIdx + 1);
+      customFlags = argv.slice(customIdx + 1);
 
       // Remove custom args from input.
       argv = argv.slice(0, customIdx);
@@ -153,7 +153,7 @@ var createFn = function (flags) {
       // Camel-case flags.
       .mapKeys(function (val, key) { return _.camelCase(key); })
       // Add in custom flags if found earlier.
-      .merge(customArgs.length > 0 ? { _customArgs: customArgs } : {})
+      .merge(customFlags.length > 0 ? { _customFlags: customFlags } : {})
       .value();
   };
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -5,7 +5,6 @@ var exec = require("child_process").exec;
 var _ = require("lodash");
 var async = require("async");
 var chalk = require("chalk");
-var argvSplit = require("argv-split");
 var log = require("./log");
 var Tracker = require("./utils/tracker");
 var Config = require("./config");
@@ -33,40 +32,42 @@ var cmdStr = function (cmd, opts) {
     (opts.taskEnv ? ", Environment: " + chalk.magenta(JSON.stringify(opts.taskEnv)) : "");
 };
 
-// Helper for merging in custom options.
-var cmdWithCustom = function (cmd, opts) {
+/**
+ * Merge custom commands (`--`) into chosen script command + add to environment.
+ *
+ * Always reads and updates `_BUILDER_ARGS_CUSTOM_FLAGS` env var.
+ * _May_ also append `-- <extra args>` to command.
+ *
+ * @param {String} cmd  Command
+ * @param {Object} opts Options object
+ * @param {Object} env  Environment object
+ * @returns {String}    Updated command
+ */
+var cmdWithCustom = function (cmd, opts, env) {
   opts = opts || {};
-  var customArgs = (opts || {})._customArgs || [];
+  env = env || {};
+
+  // Start with command line flags.
+  var customFlags = (opts || {})._customFlags || [];
+  try {
+    // Extract custom flags from environment
+    customFlags = customFlags.concat(JSON.parse(env._BUILDER_ARGS_CUSTOM_FLAGS) || []);
+  } catch (err) {
+    // Ignore parsing errors.
+  }
 
   // Base case: No custom arguments to add.
-  if (customArgs.length === 0) {
+  if (customFlags.length === 0) {
     return cmd;
   }
 
-  // Scenario: A base command may have `--` already like `foo -- --bar` which
-  // we need to add to. The hard part is the command may alternately be
-  // something perverse like: `foo "totally -- not extra args"` where we need
-  // to add the `--` to.
-  //
-  // This means _parsing_ a full command string, which we've tried to avoid
-  // doing. So, current library of choice is:
-  // - https://github.com/kaelzhang/node-argv-split
-  //
-  // Other working candidates:
-  // - https://github.com/gabrieleds/node-argv (brings in `minimist` too)
-  //
-  // All of these libraries are a bit wonky / incomplete, so we only _detect_
-  // if `--` is pre-existing before appending to the existing command. But,
-  // for safety we don't mutate the original command (besides appending).
-  var parsed = argvSplit(cmd);
-  var haveCustom = parsed.indexOf("--") > 0;
+  // If we have custom flag commands from here, then add them to env.
+  env._BUILDER_ARGS_CUSTOM_FLAGS = JSON.stringify(customFlags);
 
-  // Only add the `--` token if _not_ already there and _is_ a builder task.
-  var isBuilderTask = opts._isBuilderTask === true;
-  var addCustomToken = isBuilderTask && !haveCustom;
-
-  // Add in the custom args with/without `--` token.
-  return cmd + (addCustomToken ? " -- " : " ") + customArgs.join(" ");
+  // Only add the custom flags to non-builder tasks.
+  return opts._isBuilderTask === true ?
+    cmd :
+    cmd + " " + customFlags.join(" ");
 };
 
 /**
@@ -79,12 +80,14 @@ var cmdWithCustom = function (cmd, opts) {
  * @returns {Object}            Child process object
  */
 var run = function (cmd, shOpts, opts, callback) {
-  cmd = cmdWithCustom(cmd, opts);
-
-  // Update shell options.
+  // Update shell options and ensure basic structure.
   shOpts = _.extend({
-    maxBuffer: MAX_BUFFER
+    maxBuffer: MAX_BUFFER,
+    env: {}
   }, shOpts);
+
+  // Mutate environment and return new command with `--` custom flags.
+  cmd = cmdWithCustom(cmd, opts, shOpts.env);
 
   // Check if buffered output or piped.
   var buffer = opts.buffer;

--- a/lib/task.js
+++ b/lib/task.js
@@ -74,6 +74,9 @@ Task.prototype.toString = function () {
 /**
  * Is this task another builder command?
  *
+ * _Note_: Naive. Only captures `builder` at start of command.
+ * See: https://github.com/FormidableLabs/builder/issues/93
+ *
  * @param   {String} task   Task
  * @returns {Boolean}       Is this task a passthrough?
  */

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "builder": "bin/builder.js"
   },
   "dependencies": {
-    "argv-split": "^1.0.0",
     "async": "^1.4.2",
     "chalk": "^1.1.1",
     "js-yaml": "^3.4.3",


### PR DESCRIPTION
* Refactor to use environment instead of `--` appending to propagate to
  `builder` commands. Fixes #92
* Add note for https://github.com/FormidableLabs/builder/issues/93
* Remove `argv-split` as we're not parsing commands anymore.

/cc @zachhale @coopy 