### PR TITLE
Revise `PATH`, `NODE_PATH` ordering + add `--expand-archetype` flag

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,14 @@
 History
 =======
 
+## Current
+
+* Revises `PATH`, `NODE_PATH` ordering to place archetype first, then root
+  project.
+* Add `--expand-archetype` flag to expand `node_modules/<archetype` tokens in
+  task strings.
+  [builder-victory-component#23](https://github.com/FormidableLabs/builder-victory-component/issues/23)
+
 ## 2.7.1
 
 * Propagate `--` flags via environment instead of command line mutation.

--- a/lib/args.js
+++ b/lib/args.js
@@ -35,6 +35,11 @@ var FLAG_BAIL = {
   types: [Boolean],
   default: true
 };
+var FLAG_EXPAND_ARCHETYPE = {
+  desc: "Expand occurences of `node_modules/<archetype>` with full path (default: `false`)",
+  types: [Boolean],
+  default: false
+};
 var FLAG_HELP = {
   desc: "Display help and exit",
   types: [Boolean],
@@ -60,11 +65,13 @@ var FLAGS = {
   },
 
   run: {
+    "expand-archetype": FLAG_EXPAND_ARCHETYPE,
     tries: FLAG_TRIES,
     setup: FLAG_SETUP
   },
 
   concurrent: {
+    "expand-archetype": FLAG_EXPAND_ARCHETYPE,
     tries: FLAG_TRIES,
     setup: FLAG_SETUP,
     queue: FLAG_QUEUE,
@@ -73,6 +80,7 @@ var FLAGS = {
   },
 
   envs: {
+    "expand-archetype": FLAG_EXPAND_ARCHETYPE,
     tries: FLAG_TRIES,
     setup: FLAG_SETUP,
     queue: FLAG_QUEUE,

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,20 +34,26 @@ var Config = module.exports = function (cfg) {
     return memo.concat([name, name + "-dev"]);
   }, []);
 
-  // Array of [name, package.json object] pairs.
-  var pkgs = this._loadPkgs(this.archetypes);
-
-  // Array of [name, scripts|config array] pairs.
-  this.scripts = this._loadScripts(pkgs);
-  this.configs = this._loadConfigs(pkgs);
+  // Array of `{ name, mod, path, scripts, config }`
+  this.pkgs = this._loadPkgs(this.archetypes);
 };
 
-// Expose `require()` for testing.
-//
-// Tests often have needs to mock `fs` which Node 4+ `require`-ing won't work
-// with, defeat the internal `require` cache, etc.
+/**
+ * Return imported module and full path to installed directory.
+ *
+ * Also to expose `require()` for testing.
+ *
+ * Tests often have needs to mock `fs` which Node 4+ `require`-ing won't work
+ * with, defeat the internal `require` cache, etc.
+ *
+ * @param {String} mod  Module name or path.
+ * @returns {Object}    `{ mod: MODULE, path: FULL_PATH_TO_MODULE }` object
+ */
 Config.prototype._lazyRequire = function (mod) {
-  return require(mod); // eslint-disable-line global-require
+  return {
+    mod: require(mod), // eslint-disable-line global-require
+    path: path.dirname(require.resolve(mod))
+  };
 };
 
 /**
@@ -88,7 +94,7 @@ Config.prototype._loadConfig = function (cfg) {
  * Archetype package.json.
  *
  * @param   {String} name   Archetype name
- * @returns {Object}        Package.json object
+ * @returns {Object}        Object of `{ mod: Package, path: FULL_PATH_TO_MOD }`
  */
 Config.prototype._loadArchetypePkg = function (name) {
   var pkg;
@@ -113,7 +119,7 @@ Config.prototype._loadArchetypePkg = function (name) {
     throw err;
   }
 
-  return pkg || {};
+  return pkg;
 };
 
 /**
@@ -125,18 +131,32 @@ Config.prototype._loadArchetypePkg = function (name) {
  * - Archetypes in _reverse_ order in `.builderrc`
  *
  * @param   {Array} archetypes  Archetype names
- * @returns {Array}             Array of [name, package.json object] pairs
+ * @returns {Array}             Array of `{ name, mod, path, scripts, config }`
  */
 Config.prototype._loadPkgs = function (archetypes) {
   var CWD_PKG = this._lazyRequire(path.join(process.cwd(), "package.json")) || {};
 
-  return [["ROOT", CWD_PKG]].concat(_(archetypes)
+  // Load base packages.
+  var pkgs = [_.extend({ name: "ROOT" }, CWD_PKG)].concat(_(archetypes)
     .map(function (name) {
       /*eslint-disable no-invalid-this*/
-      return [name, this._loadArchetypePkg(name)];
+      return _.extend({ name: name }, this._loadArchetypePkg(name));
     }, this)
     .reverse()
     .value());
+
+  // Add scripts, config.
+  pkgs = _.mapValues(pkgs, function (pkg) {
+    /*eslint-disable no-invalid-this*/
+    var mod = pkg.mod || {};
+
+    return _.extend({
+      config: mod.config,
+      scripts: pkg.name === "ROOT" ? mod.scripts || {} : this._loadArchetypeScripts(pkg)
+    }, pkg);
+  }, this);
+
+  return pkgs;
 };
 
 /**
@@ -144,11 +164,11 @@ Config.prototype._loadPkgs = function (archetypes) {
  *
  * _Note_: We filter out any `builder:`-prefaced commands.
  *
- * @param   {Object} pkg    Archetype package.json object
+ * @param   {Object} pkg    Archetype `{ name, mod, path }` object
  * @returns {Object}        Package.json scripts object
  */
 Config.prototype._loadArchetypeScripts = function (pkg) {
-  var scripts = pkg.scripts || {};
+  var scripts = (pkg.mod || {}).scripts || {};
   return _(scripts)
     .pairs()
     // Remove `builder:` internal tasks.
@@ -158,41 +178,26 @@ Config.prototype._loadArchetypeScripts = function (pkg) {
 };
 
 /**
- * Load archetype scripts.
- *
- * @param   {Array} pkgs  Array of [name, package.json object] pairs.
- * @returns {Array}       Array of script objects
- */
-Config.prototype._loadScripts = function (pkgs) {
-  return _.map(pkgs, function (pair) {
-    /*eslint-disable no-invalid-this*/
-    var name = pair[0];
-    var pkg = pair[1];
-    var scripts = name === "ROOT" ? pkg.scripts || {} : this._loadArchetypeScripts(pkg);
-
-    return [name, scripts];
-  }, this);
-};
-
-/**
  * Return display-friendly list of package.json fields commands.
  *
- * @param   {Array} objs        Array of package.json data.
- * @param   {Array} archetypes  Archetype names to filter to (Default: all)
- * @returns {String}            Display string.
+ * @param   {String}  field       Field name to extract
+ * @param   {Array}   archetypes  Archetype names to filter to (Default: all)
+ * @returns {String}              Display string.
  */
-Config.prototype._displayFields = function (objs, archetypes) {
+Config.prototype._displayFields = function (field, archetypes) {
+  var pkgs = this.pkgs;
+
   // Get filtered list of fields.
   if ((archetypes || []).length) {
-    objs = _.filter(objs, function (pair) {
-      return _.contains(archetypes, pair[0]);
+    pkgs = _.filter(pkgs, function (pkg) {
+      return _.contains(archetypes, pkg.name);
     });
   }
 
   // First, get all keys.
-  var keys = _(objs)
-    .map(function (pair) {
-      return _.keys(pair[1]);
+  var keys = _(pkgs)
+    .map(function (pkg) {
+      return _.keys(pkg[field]);
     })
     .flatten()
     .sortBy(function (name) {
@@ -205,10 +210,10 @@ Config.prototype._displayFields = function (objs, archetypes) {
 
   // Then, map in order.
   return _.map(keys, function (key) {
-    var tasks = _(objs)
-      .filter(function (pair) { return pair[1][key]; })
-      .map(function (pair) {
-        return "\n    " + chalk.gray("[" + pair[0] + "]") + " " + pair[1][key];
+    var tasks = _(pkgs)
+      .filter(function (pkg) { return pkg[field][key]; })
+      .map(function (pkg) {
+        return "\n    " + chalk.gray("[" + pkg.name + "]") + " " + pkg[field][key];
       })
       .value()
       .join("");
@@ -224,19 +229,7 @@ Config.prototype._displayFields = function (objs, archetypes) {
  * @returns {String}            Display string.
  */
 Config.prototype.displayScripts = function (archetypes) {
-  return this._displayFields(this.scripts, archetypes);
-};
-
-/**
- * Load archetype configs.
- *
- * @param   {Array} pkgs  Array of [name, package.json object] pairs.
- * @returns {Array}       Array of config objects
- */
-Config.prototype._loadConfigs = function (pkgs) {
-  return _.map(pkgs, function (pair) {
-    return [pair[0], pair[1].config || {}];
-  });
+  return this._displayFields("scripts", archetypes);
 };
 
 /**
@@ -246,20 +239,21 @@ Config.prototype._loadConfigs = function (pkgs) {
  * @returns {String}            Display string.
  */
 Config.prototype.displayConfigs = function (archetypes) {
-  return this._displayFields(this.configs, archetypes);
+  return this._displayFields("config", archetypes);
 };
 
 /**
  * Get list of tasks in preferred execution order.
  *
  * @param   {String} cmd  Script command
- * @returns {Array}       List of ordered matches
+ * @returns {Array}       List of ordered matches of `{ archetypeName, archetypePath, cmd }`
  */
 Config.prototype.getCommands = function (cmd) {
-  return _(this.scripts)
-    .map(function (pair) { return pair[1]; })
-    .pluck(cmd)
-    .filter(_.identity)
+  return _(this.pkgs)
+    .map(function (pkg) {
+      return { archetypeName: pkg.name, archetypePath: pkg.path, cmd: pkg.scripts[cmd] };
+    })
+    .filter(function (obj) { return obj.cmd; })
     .value();
 };
 
@@ -299,9 +293,9 @@ Object.defineProperties(Config.prototype, {
      * @returns {Object} environment object.
      */
     get: function () {
-      var configs = this.configs;
-      var configNames = _(configs)
-        .map(function (pair) { return _.keys(pair[1]); })
+      var pkgs = this.pkgs;
+      var configNames = _(pkgs)
+        .map(function (pkg) { return _.keys(pkg.config); })
         .flatten()
         .uniq()
         .value();
@@ -309,9 +303,9 @@ Object.defineProperties(Config.prototype, {
       // Take "first" config value in arrays as "winning" value.
       return _(configNames)
         .map(function (name) {
-          return [name, _.find(configs, function (pair) {
-            return _.has(pair[1], name);
-          })[1][name]];
+          return [name, _.find(pkgs, function (pkg) {
+            return _.has(pkg.config, name);
+          }).config[name]];
         })
         .object()
         .value();

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -63,8 +63,9 @@ Environment.prototype.updatePath = function (archetypePaths) {
     .split(DELIM)
     .filter(function (x) { return x; });
 
-  return [CWD_BIN]
+  return []
     .concat(archetypePaths || [])
+    .concat([CWD_BIN])
     .concat(basePath)
     .join(DELIM);
 };
@@ -86,8 +87,9 @@ Environment.prototype.updateNodePath = function (archetypeNodePaths) {
     .split(DELIM)
     .filter(function (x) { return x; });
 
-  return [CWD_NODE_PATH]
+  return []
     .concat(archetypeNodePaths || [])
+    .concat([CWD_NODE_PATH])
     .concat(baseNodePath)
     .join(DELIM);
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -2,6 +2,7 @@
 /*eslint max-params: [2, 4]*/
 
 var exec = require("child_process").exec;
+var path = require("path");
 var _ = require("lodash");
 var async = require("async");
 var chalk = require("chalk");
@@ -65,9 +66,85 @@ var cmdWithCustom = function (cmd, opts, env) {
   env._BUILDER_ARGS_CUSTOM_FLAGS = JSON.stringify(customFlags);
 
   // Only add the custom flags to non-builder tasks.
-  return opts._isBuilderTask === true ?
-    cmd :
-    cmd + " " + customFlags.join(" ");
+  return cmd + (opts._isBuilderTask === true ? "" : " " + customFlags.join(" "));
+};
+
+/**
+ * Replace all instances of a token.
+ *
+ * _Note_: Only replaces in the following cases:
+ *
+ * - `^<token>`: Token is very first string.
+ * - `[\s\t]<token>`: Whitespace before token.
+ * - `['"]<token>`: Quotes before token.
+ *
+ * @param {String} str    String to parse
+ * @param {String} token  Token to replace
+ * @param {String} sub    Replacement
+ * @returns {String}      Mutated string.
+ */
+var replaceToken = function (str, token, sub) {
+  var tokenRe = new RegExp("(^|\\s|\\'|\\\")(" + _.escapeRegExp(token) + ")", "g");
+
+  return str.replace(tokenRe, function (match, prelimMatch, tokenMatch/* offset, origStr*/) {
+    // Sanity check.
+    if (tokenMatch !== token) {
+      throw new Error("Bad match " + match + " for token " + token);
+    }
+
+    return prelimMatch + sub;
+  });
+};
+
+/**
+ * Expand file paths for archetype within chosen script command.
+ *
+ * @param {String} cmd  Command
+ * @param {Object} opts Options object
+ * @param {Object} env  Environment object
+ * @returns {String}    Updated command
+ */
+var expandArchetype = function (cmd, opts, env) {
+  opts = opts || {};
+  env = env || {};
+
+  // Short-circuit if no expansion.
+  var expand = opts.expandArchetype || env._BUILDER_ARGS_EXPAND_ARCHETYPE === "true";
+  if (expand !== true) {
+    return cmd;
+  }
+
+  // Mark environment.
+  env._BUILDER_ARGS_EXPAND_ARCHETYPE = "true";
+
+  // Create regex around archetype controlling this command.
+  var archetypeName = opts._archetypeName;
+  if (!archetypeName) {
+    // This would be a programming error in builder itself.
+    // Should have been validated out to never happen.
+    throw new Error("Have --expand-archetype but no archetype name");
+  } else if (archetypeName === "ROOT") {
+    // Skip expanding the "ROOT" archetype.
+    //
+    // The root project should have a predictable install level for an archetype
+    // so we do this for safety.
+    //
+    // We _could_ reconsider this and pass in _all_ archetypes and expand them
+    // all everywhere.
+    return cmd;
+  }
+
+  // Infer full path to archetype.
+  var archetypePath = opts._archetypePath;
+  if (!archetypePath) {
+    // Sanity check for programming error.
+    throw new Error("Have --expand-archetype but no archetype path");
+  }
+
+  // Create final token for replacing.
+  var archetypeToken = path.join("node_modules", archetypeName);
+
+  return replaceToken(cmd, archetypeToken, archetypePath);
 };
 
 /**
@@ -86,11 +163,16 @@ var run = function (cmd, shOpts, opts, callback) {
     env: {}
   }, shOpts);
 
-  // Mutate environment and return new command with `--` custom flags.
-  cmd = cmdWithCustom(cmd, opts, shOpts.env);
-
-  // Check if buffered output or piped.
   var buffer = opts.buffer;
+  var env = shOpts.env;
+
+  // Mutation steps for command. Separated for easier ordering / testing.
+  //
+  // Mutate env and return new command w/ `--` custom flags.
+  cmd = cmdWithCustom(cmd, opts, env);
+  // Mutate env and return new command w/ file paths from the archetype itself.
+  cmd = expandArchetype(cmd, opts, env);
+
 
   log.info("proc:start", cmdStr(cmd, opts));
   var proc = exec(cmd, shOpts, function (err, stdout, stderr) {
@@ -264,6 +346,8 @@ var createFinish = function (shOpts, opts, tracker, callback) {
 runner = module.exports = {
   // Helpers.
   _cmdWithCustom: cmdWithCustom,
+  _expandArchetype: expandArchetype,
+  _replaceToken: replaceToken,
 
   /**
    * Run a single task.

--- a/lib/task.js
+++ b/lib/task.js
@@ -109,13 +109,13 @@ Task.prototype.isPassthrough = function (task) {
  * Get executable command.
  *
  * @param   {String} cmd  Script command
- * @returns {String}      String to execute
+ * @returns {Object}      Command object `{ archetype, cmd }`
  */
 Task.prototype.getCommand = function (cmd) {
   // Select first non-passthrough command.
-  var task = _.find(this._config.getCommands(cmd), function (curCmd) {
+  var task = _.find(this._config.getCommands(cmd), function (obj) {
     /*eslint-disable no-invalid-this*/
-    return !this.isPassthrough(curCmd);
+    return !this.isPassthrough(obj.cmd);
   }, this);
 
   // Error out if still can't find task.
@@ -129,13 +129,15 @@ Task.prototype.getCommand = function (cmd) {
 /**
  * Merge base options with custom options.
  *
- * @param   {String} task   Task
+ * @param   {Object} task   Task object `{ archetype, cmd }`
  * @param   {Object} opts   Custom options
  * @returns {Object}        Combined options
  */
 Task.prototype.getOpts = function (task, opts) {
   return _.extend({
-    _isBuilderTask: this.isBuilderTask(task)
+    _isBuilderTask: this.isBuilderTask(task.cmd),
+    _archetypeName: task.archetypeName,
+    _archetypePath: task.archetypePath
   }, opts);
 };
 
@@ -217,9 +219,9 @@ Task.prototype.run = function (callback) {
   var flags = args.run(this.argv);
   var opts = this.getOpts(task, flags);
 
-  log.info(this._action, this._command + chalk.gray(" - " + task));
+  log.info(this._action, this._command + chalk.gray(" - " + task.cmd));
 
-  return this._runner.run(task, { env: env }, opts, callback);
+  return this._runner.run(task.cmd, { env: env }, opts, callback);
 };
 
 /**
@@ -233,13 +235,15 @@ Task.prototype.concurrent = function (callback) {
   var cmds = this._commands;
   var tasks = cmds.map(this.getCommand.bind(this));
   var flags = args.concurrent(this.argv);
-  var opts = this.getOpts(tasks[0] || "", flags);
+  var opts = this.getOpts(tasks[0] || {}, flags);
 
   log.info(this._action, cmds.join(", ") + tasks.map(function (t, i) {
-    return "\n * " + cmds[i] + chalk.gray(" - " + t);
+    return "\n * " + cmds[i] + chalk.gray(" - " + t.cmd);
   }).join(""));
 
-  this._runner.concurrent(tasks, { env: env }, opts, callback);
+  this._runner.concurrent(
+    tasks.map(function (task) { return task.cmd; }),
+    { env: env }, opts, callback);
 };
 
 Task.prototype._parseJson = function (objStr) {
@@ -303,7 +307,7 @@ Task.prototype.envs = function (callback) {
     return callback(err);
   }
 
-  this._runner.envs(task, { env: env }, opts, callback);
+  this._runner.envs(task.cmd, { env: env }, opts, callback);
 };
 
 /**

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -51,6 +51,7 @@ describe("lib/args", function () {
     it("handles defaults for run flags", function () {
       expect(_flags(args.run(argv))).to.deep.equal({
         tries: 1,
+        expandArchetype: false,
         setup: null
       });
     });
@@ -59,6 +60,7 @@ describe("lib/args", function () {
       argv = argv.concat(["--tries=2"]);
       expect(_flags(args.run(argv))).to.deep.equal({
         tries: 2,
+        expandArchetype: false,
         setup: null
       });
     });
@@ -68,16 +70,19 @@ describe("lib/args", function () {
 
       expect(_flags(args.run(argv.concat(["--tries=-1"])))).to.deep.equal({
         tries: 1,
+        expandArchetype: false,
         setup: null
       });
 
       expect(_flags(args.run(argv.concat(["--tries=BAD"])))).to.deep.equal({
         tries: 1,
+        expandArchetype: false,
         setup: null
       });
 
       expect(_flags(args.run(argv.concat(["--tries="])))).to.deep.equal({
         tries: 1,
+        expandArchetype: false,
         setup: null
       });
     });
@@ -86,6 +91,7 @@ describe("lib/args", function () {
       argv = argv.concat(["--setup=foo"]);
       expect(_flags(args.run(argv))).to.deep.equal({
         tries: 1,
+        expandArchetype: false,
         setup: "foo"
       });
     });
@@ -94,6 +100,7 @@ describe("lib/args", function () {
       argv = argv.concat(["--setup="]);
       expect(_flags(args.run(argv))).to.deep.equal({
         tries: 1,
+        expandArchetype: false,
         setup: null
       });
     });
@@ -107,6 +114,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -118,6 +126,7 @@ describe("lib/args", function () {
         queue: 2,
         buffer: true,
         tries: 2,
+        expandArchetype: false,
         setup: null,
         bail: false
       });
@@ -128,6 +137,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: true,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -136,6 +146,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -144,6 +155,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -152,6 +164,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: true,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -160,6 +173,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: true,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -170,6 +184,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -178,6 +193,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: false
       });
@@ -186,6 +202,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: false
       });
@@ -194,6 +211,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -202,6 +220,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -213,6 +232,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -221,6 +241,7 @@ describe("lib/args", function () {
         queue: 2,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -229,6 +250,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -240,6 +262,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -248,6 +271,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 2,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -256,6 +280,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -267,6 +292,7 @@ describe("lib/args", function () {
         queue: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: false
       });
@@ -283,6 +309,7 @@ describe("lib/args", function () {
         envsPath: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -297,6 +324,7 @@ describe("lib/args", function () {
         envsPath: dummyPath,
         buffer: true,
         tries: 2,
+        expandArchetype: false,
         setup: null,
         bail: true
       });
@@ -309,6 +337,7 @@ describe("lib/args", function () {
         envsPath: null,
         buffer: false,
         tries: 1,
+        expandArchetype: false,
         setup: null,
         bail: true
       });

--- a/test/server/spec/lib/runner.spec.js
+++ b/test/server/spec/lib/runner.spec.js
@@ -112,4 +112,45 @@ describe("lib/runner", function () {
 
   });
 
+  describe("#replaceToken", function () {
+    var replaceToken = runner._replaceToken;
+
+    it("leaves strings without tokens unchanged", function () {
+      expect(replaceToken("", "t", "r")).to.equal("");
+      expect(replaceToken(" ", "t", "r")).to.equal(" ");
+      expect(replaceToken("  ", "t", "r")).to.equal("  ");
+      expect(replaceToken("no_match", "T", "R")).to.equal("no_match");
+    });
+
+    it("skips tokens after slashes", function () {
+      expect(replaceToken("/TOK", "TOK", "SUB")).to.equal("/TOK");
+      expect(replaceToken("hello ./TOK", "TOK", "SUB")).to.equal("hello ./TOK");
+      expect(replaceToken("/TOK/TOK/TOK", "TOK", "SUB")).to.equal("/TOK/TOK/TOK");
+    });
+
+    it("skips tokens after characters", function () {
+      expect(replaceToken("aTOK", "TOK", "SUB")).to.equal("aTOK");
+      expect(replaceToken("TKTOK ", "TOK", "SUB")).to.equal("TKTOK ");
+      expect(replaceToken("TO.*KTOK", "TOK", "SUB")).to.equal("TO.*KTOK");
+    });
+
+    it("replaces at the beginning of strings", function () {
+      expect(replaceToken("TOK", "TOK", "SUB")).to.equal("SUB");
+      expect(replaceToken("TOK hello", "TOK", "SUB")).to.equal("SUB hello");
+      expect(replaceToken("TOK [hello]*", "TOK", "SUB")).to.equal("SUB [hello]*");
+      expect(replaceToken("TOK/  \/hi .* TOk/ ", "TOK", "SUB")).to.equal("SUB/  \/hi .* TOk/ ");
+    });
+
+    it("replaces after quotes", function () {
+      expect(replaceToken("'TOK' \"TOK/More\"", "TOK", "SUB")).to.equal("'SUB' \"SUB/More\"");
+      expect(replaceToken("T/K hello 'T/K/T/K'", "T/K", "S/B")).to.equal("S/B hello 'S/B/T/K'");
+    });
+
+    it("replaces after whitespace", function () {
+      expect(replaceToken("TOK TOK", "TOK", "SUB")).to.equal("SUB SUB");
+      expect(replaceToken("TOK hello TOK", "TOK", "SUB")).to.equal("SUB hello SUB");
+      expect(replaceToken("echo TOK/foo/TOK", "TOK", "SUB")).to.equal("echo SUB/foo/TOK");
+    });
+  });
+
 });


### PR DESCRIPTION
### Overview

* Revises `PATH`, `NODE_PATH` ordering to place archetype first, then root
  project.
* Add `--expand-archetype` flag to expand `node_modules/<archetype` tokens in
  task strings.
  Fixes FormidableLabs/builder-victory-component#23
* Refactors `config.js` to streamline package.json ingestion and pass back
  more data.
* Updated docs and lots of tests.

### Notes

#### PATH, NODE_PATH Ordering Changes

This PR subsumes https://github.com/FormidableLabs/builder/pull/90 and switches to "archetype-first" for path resolution.

#### Victory Git Installs
For `victory` git installs to work, we need additional changes in the archetype (add this new flag to `npm:postinstall` and webpack changes). https://github.com/FormidableLabs/builder-victory-component/compare/feature-expand-archetype

/cc @boygirl @coopy @exogen @zachhale @chaseadamsio @shakefon 