### PR TITLE
BUG: Allow root package.json to omit config.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -215,9 +215,9 @@ Config.prototype._displayFields = function (field, archetypes) {
   // Then, map in order.
   return _.map(keys, function (key) {
     var tasks = _.chain(pkgs)
-      .filter(function (pkg) { return pkg[field][key]; })
+      .filter(function (pkg) { return _.get(pkg, [field, key]); })
       .map(function (pkg) {
-        return "\n    " + chalk.gray("[" + pkg.name + "]") + " " + pkg[field][key];
+        return "\n    " + chalk.gray("[" + pkg.name + "]") + " " + _.get(pkg, [field, key]);
       })
       .value()
       .join("");

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -216,6 +216,38 @@ describe("bin/builder-core", function () {
         done();
       });
     });
+
+    // Regression test for: https://github.com/FormidableLabs/builder/issues/113
+    it("runs help with config in archetype", function (done) {
+      base.sandbox.spy(Task.prototype, "help");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "package.json": "{}",
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "config": {
+                "_test_message": "from archetype"
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "help"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.help).to.be.calledOnce;
+        expect(logStubs.info)
+          .to.be.calledWithMatch("Task Configs").and
+          .to.be.calledWithMatch("_test_message");
+
+        done();
+      });
+    });
+
   });
 
   describe("builder run", function () {
@@ -265,6 +297,7 @@ describe("bin/builder-core", function () {
       });
 
     }));
+
     it("runs with quiet log output", stdioWrap(function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({


### PR DESCRIPTION
* Add permissive traverse of package.json's when searching for configs. Fixes #113
* Add regression test.

/cc @jchip @shakefon 