### PR TITLE
Hack a quick fix to concurrent buffering issues

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@ History
 
 ## Unreleased
 
+* Add `console.log()` hack to flush buffers in `builder concurrent --buffer`.
+  [#120](https://github.com/FormidableLabs/builder/issues/120)
 * Add auto-TOC to README.md.
   [#101](https://github.com/FormidableLabs/builder/issues/101)
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -185,6 +185,13 @@ var run = function (cmd, shOpts, opts, callback) {
     if (buffer) {
       process.stdout.write(stdout);
       process.stderr.write(stderr);
+      // Hack to help get `stdout|stderr` process streams flushed. We
+      // _shouldn't_ need to do this per:
+      // https://nodejs.org/api/process.html#process_process_stdout
+      // but here we are...
+      //
+      // TODO: https://github.com/FormidableLabs/builder/issues/120
+      console.log(""); // eslint-disable-line no-console
     }
 
     log[level]("proc:end:" + code, cmdStr(cmd, opts));


### PR DESCRIPTION
Add `console.log()` hack to flush buffers in `builder concurrent --buffer`. #120

/cc @exogen 

