### PR TITLE
Spawn commands like npm

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,11 @@ History
 
 ## Unreleased
 
+* **BREAKING**: Remove `--unlimited-buffer` command line option. It is unneeded
+  with switch to `spawn`.
+* Switch from `exec` to `spawn` child process spawning for better stdio/stderr
+  propagation. ( [@exogen][] )
+  [#20](https://github.com/FormidableLabs/builder/issues/20)
 * Add auto-TOC to README.md.
   [#101](https://github.com/FormidableLabs/builder/issues/101)
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,6 @@ Flags:
 * `--setup`: Single task to run for the entirety of `<action>`
 * `--quiet`: Silence logging
 * `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
-* `--unlimited-buffer`: Unlimited shell output buffer.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 
@@ -303,7 +302,6 @@ Flags:
 * `--[no-]bail`: End all processes after the first failure (default: `true`)
 * `--quiet`: Silence logging
 * `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
-* `--unlimited-buffer`: Unlimited shell output buffer.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 
@@ -346,7 +344,6 @@ Flags:
 * `--envs-path`: Path to JSON env variable array file (default: `null`)
 * `--quiet`: Silence logging
 * `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
-* `--unlimited-buffer`: Unlimited shell output buffer.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -71,11 +71,6 @@ var FLAGS = {
       desc: "Level to log at (`info`, `warn`, `error`, `none`)",
       types: [String],
       default: "info"
-    },
-    "unlimited-buffer": {
-      desc: "Use an unlimited buffer for shell commands",
-      types: [Boolean],
-      default: false
     }
   },
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -145,8 +145,7 @@ var expandArchetype = function (cmd, opts, env) {
 var run = function (cmd, shOpts, opts, callback) {
   // Buffer output (for concurrent usage).
   var buffer = !!opts.buffer;
-  var stdoutBufs = [];
-  var stderrBufs = [];
+  var bufs = []; // { type: `stdio|stderr`, data: `data` }
 
   // Copied from npm's lib/utils/lifecycle.js
   var sh = "sh";
@@ -181,8 +180,9 @@ var run = function (cmd, shOpts, opts, callback) {
 
     // Output buffered output.
     if (buffer) {
-      process.stdout.write(Buffer.concat(stdoutBufs).toString());
-      process.stderr.write(Buffer.concat(stderrBufs).toString());
+      _.each(bufs, function (buf) {
+        process[buf.type].write(buf.data.toString());
+      });
     }
 
     log[level]("proc:end:" + code, cmdStr(cmd, opts));
@@ -192,10 +192,10 @@ var run = function (cmd, shOpts, opts, callback) {
   // Gather buffered output in memory.
   if (buffer) {
     proc.stdout.on("data", function (data) {
-      stdoutBufs.push(data);
+      bufs.push({ type: "stdout", data: data });
     });
     proc.stderr.on("data", function (data) {
-      stderrBufs.push(data);
+      bufs.push({ type: "stderr", data: data });
     });
   }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -180,7 +180,7 @@ var run = function (cmd, shOpts, opts, callback) {
 
     // Output buffered output.
     if (buffer) {
-      _.each(bufs, function (buf) {
+      bufs.forEach(function (buf) {
         process[buf.type].write(buf.data.toString());
       });
     }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -143,6 +143,7 @@ var expandArchetype = function (cmd, opts, env) {
  * @returns {Object}            Child process object
  */
 var run = function (cmd, shOpts, opts, callback) {
+  // Copied from npm's lib/utils/lifecycle.js
   var sh = "sh";
   var shFlag = "-c";
 
@@ -152,6 +153,7 @@ var run = function (cmd, shOpts, opts, callback) {
     stdio: "inherit"
   }, shOpts);
 
+  // Copied from npm's lib/utils/lifecycle.js
   if (process.platform === "win32") {
     sh = process.env.comspec || "cmd";
     shFlag = "/d /s /c";

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,5 @@
 "use strict";
-/*eslint max-params: [2, 4]*/
+/*eslint max-params: [2, 4], max-statements: [2, 20] */
 
 var path = require("path");
 var _ = require("lodash");
@@ -143,6 +143,11 @@ var expandArchetype = function (cmd, opts, env) {
  * @returns {Object}            Child process object
  */
 var run = function (cmd, shOpts, opts, callback) {
+  // Buffer output (for concurrent usage).
+  var buffer = !!opts.buffer;
+  var stdoutBufs = [];
+  var stderrBufs = [];
+
   // Copied from npm's lib/utils/lifecycle.js
   var sh = "sh";
   var shFlag = "-c";
@@ -150,7 +155,7 @@ var run = function (cmd, shOpts, opts, callback) {
   // Update shell options and ensure basic structure.
   shOpts = _.extend({
     env: {},
-    stdio: "inherit"
+    stdio: buffer ? "pipe" : "inherit"
   }, shOpts);
 
   // Copied from npm's lib/utils/lifecycle.js
@@ -173,9 +178,26 @@ var run = function (cmd, shOpts, opts, callback) {
   var proc = spawn(sh, [shFlag, cmd], shOpts, function (err) {
     var code = err ? err.code || 1 : 0;
     var level = code === 0 ? "info" : "warn";
+
+    // Output buffered output.
+    if (buffer) {
+      process.stdout.write(Buffer.concat(stdoutBufs).toString());
+      process.stderr.write(Buffer.concat(stderrBufs).toString());
+    }
+
     log[level]("proc:end:" + code, cmdStr(cmd, opts));
     callback(err);
   });
+
+  // Gather buffered output in memory.
+  if (buffer) {
+    proc.stdout.on("data", function (data) {
+      stdoutBufs.push(data);
+    });
+    proc.stderr.on("data", function (data) {
+      stderrBufs.push(data);
+    });
+  }
 
   return proc;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,31 +1,17 @@
 "use strict";
 /*eslint max-params: [2, 4]*/
 
-var exec = require("child_process").exec;
 var path = require("path");
 var _ = require("lodash");
 var async = require("async");
 var chalk = require("chalk");
+var spawn = require("./spawn");
 var log = require("./log");
 var Tracker = require("./utils/tracker");
 var Config = require("./config");
 var Environment = require("./environment");
 var Task = require("./task");
 var runner;
-
-// One limitation of `exec()` is that it unconditionally buffers stdout/stderr
-// input (whether piped, listened, or whatever) leading to a `maxBuffer` bug:
-// https://github.com/FormidableLabs/builder/issues/62
-//
-// We set a comfortable margin here to up the number. In the future, we could
-// just go "whole hog" and bump to `Infinity` if needed.
-//
-// Longer term, we can consider whether we want to do what npm does and use
-// `spawn` with manual OS-compatible `sh` vs. `cmd` detection, cobble together
-// our own flags and manage everything so that we can use the much more flexible
-// `spawn` instead of `exec`.
-// https://github.com/FormidableLabs/builder/issues/20
-var MAX_BUFFER = 32 * 1024 * 1024;
 
 // Helper for command strings for logging.
 var cmdStr = function (cmd, opts) {
@@ -157,15 +143,21 @@ var expandArchetype = function (cmd, opts, env) {
  * @returns {Object}            Child process object
  */
 var run = function (cmd, shOpts, opts, callback) {
-  var maxBuffer = opts.unlimitedBuffer ? Infinity : MAX_BUFFER;
+  var sh = "sh";
+  var shFlag = "-c";
 
   // Update shell options and ensure basic structure.
   shOpts = _.extend({
-    maxBuffer: maxBuffer,
-    env: {}
+    env: {},
+    stdio: "inherit"
   }, shOpts);
 
-  var buffer = opts.buffer;
+  if (process.platform === "win32") {
+    sh = process.env.comspec || "cmd";
+    shFlag = "/d /s /c";
+    shOpts.windowsVerbatimArguments = true;
+  }
+
   var env = shOpts.env;
 
   // Mutation steps for command. Separated for easier ordering / testing.
@@ -175,27 +167,13 @@ var run = function (cmd, shOpts, opts, callback) {
   // Mutate env and return new command w/ file paths from the archetype itself.
   cmd = expandArchetype(cmd, opts, env);
 
-
   log.info("proc:start", cmdStr(cmd, opts));
-  var proc = exec(cmd, shOpts, function (err, stdout, stderr) {
+  var proc = spawn(sh, [shFlag, cmd], shOpts, function (err) {
     var code = err ? err.code || 1 : 0;
     var level = code === 0 ? "info" : "warn";
-
-    // Write out buffered output.
-    if (buffer) {
-      process.stdout.write(stdout);
-      process.stderr.write(stderr);
-    }
-
     log[level]("proc:end:" + code, cmdStr(cmd, opts));
     callback(err);
   });
-
-  // Concurrent / "whenever" output.
-  if (!buffer) {
-    proc.stdout.pipe(process.stdout, { end: false });
-    proc.stderr.pipe(process.stderr, { end: false });
-  }
 
   return proc;
 };

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -28,6 +28,7 @@ var spawn = function (cmd, args, opts, callback) {
     if (error) {
       return callback(error);
     }
+
     if (code !== 0) {
       // Behave like `exec` and construct an Error object.
       var cmdStr = [cmd].concat(args).join(" ");
@@ -42,6 +43,7 @@ var spawn = function (cmd, args, opts, callback) {
       error.cmd = cmdStr;
       return callback(error);
     }
+
     return callback(null);
   });
 

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,7 +1,7 @@
 "use strict";
 /*eslint max-params: [2, 4]*/
 
-var _spawn = require("child_process").spawn;
+var childProcess = require("child_process");
 
 /**
  * Compatibility wrapper around `spawn` that makes it behave a little more
@@ -14,7 +14,7 @@ var _spawn = require("child_process").spawn;
  * @returns {EventEmitter}    The child process object.
  */
 var spawn = function (cmd, args, opts, callback) {
-  var proc = _spawn(cmd, args, opts);
+  var proc = childProcess.spawn(cmd, args, opts);
   var error;
 
   // The "error" event will almost never happen unless there's a problem at the

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,3 +1,6 @@
+"use strict";
+/*eslint max-params: [2, 4]*/
+
 var _spawn = require("child_process").spawn;
 
 /**
@@ -23,8 +26,9 @@ var spawn = function (cmd, args, opts, callback) {
 
   proc.on("close", function (code, signal) {
     if (error) {
-      callback(error);
-    } else if (code !== 0) {
+      return callback(error);
+    }
+    if (code !== 0) {
       // Behave like `exec` and construct an Error object.
       var cmdStr = [cmd].concat(args).join(" ");
       // TODO: To truly match `exec`, we'd tack on some stdout/stderr output to
@@ -36,10 +40,9 @@ var spawn = function (cmd, args, opts, callback) {
       error.code = code;
       error.signal = signal;
       error.cmd = cmdStr;
-      callback(error);
-    } else {
-      callback(null);
+      return callback(error);
     }
+    return callback(null);
   });
 
   return proc;

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,0 +1,48 @@
+var _spawn = require("child_process").spawn;
+
+/**
+ * Compatibility wrapper around `spawn` that makes it behave a little more
+ * like `exec`.
+ * @param {String} cmd        The command to run.
+ * @param {Array} args        Arguments to pass to `cmd`.
+ * @param {Object} opts       Spawn options.
+ * @param {Function} callback A function to call with an `error` or null when
+ *                            the process is done.
+ * @returns {EventEmitter}    The child process object.
+ */
+var spawn = function (cmd, args, opts, callback) {
+  var proc = _spawn(cmd, args, opts);
+  var error;
+
+  // The "error" event will almost never happen unless there's a problem at the
+  // OS level; things like "command not found" and non-zero exit codes will be
+  // normal "close" events, but with the appropriate `code` and `signal`.
+  proc.on("error", function (err) {
+    error = err;
+  });
+
+  proc.on("close", function (code, signal) {
+    if (error) {
+      callback(error);
+    } else if (code !== 0) {
+      // Behave like `exec` and construct an Error object.
+      var cmdStr = [cmd].concat(args).join(" ");
+      // TODO: To truly match `exec`, we'd tack on some stdout/stderr output to
+      // the Error message here.
+      error = new Error("Command failed: " + cmdStr + "\n");
+      // TODO: Are there signals we'd get here on a `close` event that *don't*
+      // mean that the process was killed?
+      error.killed = signal ? true : false;
+      error.code = code;
+      error.signal = signal;
+      error.cmd = cmdStr;
+      callback(error);
+    } else {
+      callback(null);
+    }
+  });
+
+  return proc;
+};
+
+module.exports = spawn;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "chai": "^3.4.1",
     "coveralls": "^2.11.4",
     "doctoc": "^1.2.0",
-    "es6-promise": "^3.2.1",
     "eslint": "^1.7.3",
     "eslint-config-defaults": "^7.0.1",
     "eslint-plugin-filenames": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chai": "^3.4.1",
     "coveralls": "^2.11.4",
     "doctoc": "^1.2.0",
+    "es6-promise": "^3.2.1",
     "eslint": "^1.7.3",
     "eslint-config-defaults": "^7.0.1",
     "eslint-plugin-filenames": "^0.1.2",

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -45,4 +45,14 @@ afterEach(function () {
   base.mockFs.restore();
   base.sandbox.restore();
   log._unsetLevel();
+  try {
+    fs.unlinkSync("stdout.log");
+  } catch (err) {
+    // No worries.
+  }
+  try {
+    fs.unlinkSync("stderr.log");
+  } catch (err) {
+    // No worries.
+  }
 });

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -11,7 +11,16 @@
 var mockFs = require("mock-fs");
 var fs = require("fs");
 var sinon = require("sinon");
+var Promise = require("es6-promise").Promise;
 var log = require("../../../lib/log");
+
+var removeFile = function (filename) {
+  return new Promise(function (resolve) {
+    fs.unlink(filename, function () {
+      resolve(); // Don't get about errors.
+    });
+  });
+};
 
 var base = module.exports = {
   // Generic test helpers.
@@ -45,14 +54,8 @@ afterEach(function () {
   base.mockFs.restore();
   base.sandbox.restore();
   log._unsetLevel();
-  try {
-    fs.unlinkSync("stdout.log");
-  } catch (err) {
-    // No worries.
-  }
-  try {
-    fs.unlinkSync("stderr.log");
-  } catch (err) {
-    // No worries.
-  }
+  return Promise.all([
+    removeFile("stdout.log"),
+    removeFile("stderr.log")
+  ]);
 });

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -13,6 +13,7 @@
 var fs = require("fs");
 var path = require("path");
 var chalk = require("chalk");
+var Promise = require("es6-promise").Promise;
 
 var pkg = require("../../../../package.json");
 var Config = require("../../../../lib/config");
@@ -22,14 +23,13 @@ var run = require("../../../../bin/builder-core");
 
 var base = require("../base.spec");
 
-var readOut = function () {
-  base.mockFs.restore();
-  return fs.readFileSync("stdout.log", { encoding: "utf8" });
-};
-
-var readErr = function () {
-  base.mockFs.restore();
-  return fs.readFileSync("stderr.log", { encoding: "utf8" });
+var readFile = function (filename) {
+  return new Promise(function (resolve, reject) {
+    base.mockFs.restore();
+    fs.readFile(filename, { encoding: "utf8" }, function (err, data) {
+      return err ? reject(err) : resolve(data);
+    });
+  });
 };
 
 describe("bin/builder-core", function () {
@@ -260,9 +260,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readOut()).to.contain("BAR_TASK");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("BAR_TASK");
+        }).then(done, done);
       });
 
     });
@@ -283,9 +284,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readOut()).to.contain("BAR_TASK");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("BAR_TASK");
+        }).then(done, done);
       });
 
     });
@@ -306,12 +308,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readOut()).to.contain("BAR_TASK");
         expect(logStubs.info).not.be.called;
         expect(logStubs.warn).not.be.called;
         expect(logStubs.error).not.be.called;
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("BAR_TASK");
+        }).then(done, done);
       });
     });
 
@@ -333,14 +336,15 @@ describe("bin/builder-core", function () {
           .that.contains("BAD_COMMAND");
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readErr()).to.contain("BAD_COMMAND");
         expect(logStubs.info).not.be.called;
         expect(logStubs.warn).not.be.called;
         expect(logStubs.error)
           .to.be.calledWithMatch("Command failed").and
           .to.be.calledWithMatch("BAD_COMMAND");
 
-        done();
+        readFile("stderr.log").then(function (data) {
+          expect(data).to.contain("BAD_COMMAND");
+        }).then(done, done);
       });
 
     });
@@ -367,9 +371,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readOut()).to.contain("FOO_TASK");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("FOO_TASK");
+        }).then(done, done);
       });
 
     });
@@ -431,9 +436,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readOut()).to.contain("ROOT_TASK");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("ROOT_TASK");
+        }).then(done, done);
       });
 
     });
@@ -462,12 +468,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(2);
-        expect(readOut())
-          .to.contain("SETUP").and
-          .to.contain("BAR_TASK").and
-          .to.contain("EXIT - BAR_TASK - 0");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("SETUP").and
+            .to.contain("BAR_TASK").and
+            .to.contain("EXIT - BAR_TASK - 0");
+        }).then(done, done);
       });
 
     });
@@ -548,13 +555,14 @@ describe("bin/builder-core", function () {
           .that.contains("BAD_COMMAND");
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(readErr()).to.contain("BAD_COMMAND");
         expect(logStubs.warn).to.be.calledWithMatch(chalk.red("1") + " tries left");
         expect(logStubs.error)
           .to.be.calledWithMatch("Command failed").and
           .to.be.calledWithMatch("BAD_COMMAND");
 
-        done();
+        readFile("stderr.log").then(function (data) {
+          expect(data).to.contain("BAD_COMMAND");
+        }).then(done, done);
       });
 
     });
@@ -578,9 +586,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(readOut()).to.contain("string - from base config");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("string - from base config");
+        }).then(done, done);
       });
     });
 
@@ -609,9 +618,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(readOut()).to.contain("string - from archetype");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("string - from archetype");
+        }).then(done, done);
       });
     });
 
@@ -644,9 +654,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(readOut()).to.contain("string - EMPTY");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("string - EMPTY");
+        }).then(done, done);
       });
     });
 
@@ -679,9 +690,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(readOut()).to.contain("string - from real env");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("string - from real env");
+        }).then(done, done);
       });
     });
 
@@ -718,9 +730,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(readOut()).to.contain("string - from real env");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data).to.contain("string - from real env");
+        }).then(done, done);
       });
     });
 
@@ -748,11 +761,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(readOut()).to.contain(
-            "WONT_EXPAND ../node_modules/mock-archetype/A_FILE.txt"
-          );
 
-          done();
+          readFile("stdout.log").then(function (data) {
+            expect(data).to.contain(
+              "WONT_EXPAND ../node_modules/mock-archetype/A_FILE.txt"
+            );
+          }).then(done, done);
         });
       });
 
@@ -779,11 +793,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(readOut()).to.contain(
-            "WONT_EXPAND other/node_modules/mock-archetype/A_FILE.txt"
-          );
 
-          done();
+          readFile("stdout.log").then(function (data) {
+            expect(data).to.contain(
+              "WONT_EXPAND other/node_modules/mock-archetype/A_FILE.txt"
+            );
+          }).then(done, done);
         });
       });
 
@@ -809,11 +824,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(readOut()).to.contain(
-            "EXPANDED " + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt")
-          );
 
-          done();
+          readFile("stdout.log").then(function (data) {
+            expect(data).to.contain(
+              "EXPANDED " + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt")
+            );
+          }).then(done, done);
         });
       });
 
@@ -842,11 +858,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(readOut()).to.contain(
-            "EXPANDED \"" + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt\"")
-          );
 
-          done();
+          readFile("stdout.log").then(function (data) {
+            expect(data).to.contain(
+              "EXPANDED \"" + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt\"")
+            );
+          }).then(done, done);
         });
       });
 
@@ -874,11 +891,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(readOut()).to.contain(
-            "EXPANDED " + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt")
-          );
 
-          done();
+          readFile("stdout.log").then(function (data) {
+            expect(data).to.contain(
+              "EXPANDED " + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt")
+            );
+          }).then(done, done);
         });
       });
 
@@ -904,11 +922,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(readOut()).to.contain(
-            "WONT_EXPAND node_modules/mock-archetype/A_FILE.txt"
-          );
 
-          done();
+          readFile("stdout.log").then(function (data) {
+            expect(data).to.contain(
+              "WONT_EXPAND node_modules/mock-archetype/A_FILE.txt"
+            );
+          }).then(done, done);
         });
       });
 
@@ -936,12 +955,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.concurrent).to.be.calledOnce;
-        expect(readOut())
-          .to.contain("ONE_TASK").and
-          .to.contain("TWO_TASK").and
-          .to.contain("THREE_TASK");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("ONE_TASK").and
+            .to.contain("TWO_TASK").and
+            .to.contain("THREE_TASK");
+        }).then(done, done);
       });
 
     });
@@ -975,12 +995,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.concurrent).to.be.calledOnce;
-        expect(readOut())
-          .to.contain("ONE_TASK").and
-          .to.contain("TWO_ROOT_TASK").and
-          .to.contain("THREE_ROOT_TASK");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("ONE_TASK").and
+            .to.contain("TWO_ROOT_TASK").and
+            .to.contain("THREE_ROOT_TASK");
+        }).then(done, done);
       });
 
     });
@@ -1023,11 +1044,12 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.concurrent).to.have.callCount(1);
-        expect(readOut())
-          .to.contain("string - from base - ONE").and
-          .to.contain("string - from base - TWO");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("string - from base - ONE").and
+            .to.contain("string - from base - TWO");
+        }).then(done, done);
       });
     });
 
@@ -1056,12 +1078,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(readOut())
-          .to.contain("ROOT hi").and
-          .to.contain("ROOT ho").and
-          .to.contain("ROOT yo");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("ROOT hi").and
+            .to.contain("ROOT ho").and
+            .to.contain("ROOT yo");
+        }).then(done, done);
       });
 
     });
@@ -1088,12 +1111,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(readOut())
-          .to.contain("ROOT hi").and
-          .to.contain("ROOT ho").and
-          .to.contain("ROOT yo");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("ROOT hi").and
+            .to.contain("ROOT ho").and
+            .to.contain("ROOT yo");
+        }).then(done, done);
       });
 
     });
@@ -1125,12 +1149,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(readOut())
-          .to.contain("ARCH hi").and
-          .to.contain("ARCH ho").and
-          .to.contain("ARCH yo");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("ARCH hi").and
+            .to.contain("ARCH ho").and
+            .to.contain("ARCH yo");
+        }).then(done, done);
       });
 
     });
@@ -1167,12 +1192,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(readOut())
-          .to.contain("ROOT hi").and
-          .to.contain("ROOT ho").and
-          .to.contain("ROOT yo");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("ROOT hi").and
+            .to.contain("ROOT ho").and
+            .to.contain("ROOT yo");
+        }).then(done, done);
       });
 
     });
@@ -1298,12 +1324,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.have.callCount(1);
-        expect(readOut())
-          .to.contain("string - from base").and
-          .to.contain("string - from array1").and
-          .to.contain("string - from array2");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("string - from base").and
+            .to.contain("string - from array1").and
+            .to.contain("string - from array2");
+        }).then(done, done);
       });
     });
 
@@ -1344,12 +1371,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.have.callCount(1);
-        expect(readOut())
-          .to.contain("string - from real env").and
-          .to.contain("string - from array1").and
-          .to.contain("string - from array2");
 
-        done();
+        readFile("stdout.log").then(function (data) {
+          expect(data)
+            .to.contain("string - from real env").and
+            .to.contain("string - from array1").and
+            .to.contain("string - from array2");
+        }).then(done, done);
       });
     });
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -13,33 +13,12 @@
 var path = require("path");
 var chalk = require("chalk");
 
-var pkg = require("../../../../package.json");
 var Config = require("../../../../lib/config");
 var Task = require("../../../../lib/task");
 var log = require("../../../../lib/log");
 var run = require("../../../../bin/builder-core");
 
 var base = require("../base.spec");
-
-// Helpers
-// **Note**: It would be great to just stub stderr, stdout in beforeEach,
-// but then we don't get test output. So, we manually stub with this wrapper.
-var stdioWrap = function (fn) {
-  return function (done) {
-    base.sandbox.stub(process.stdout, "write");
-
-    var _done = function (err) {
-      process.stdout.write.restore();
-      done(err);
-    };
-
-    try {
-      return fn(_done);
-    } catch (err) {
-      return _done(err);
-    }
-  };
-};
 
 describe("bin/builder-core", function () {
   var logStubs;
@@ -121,7 +100,7 @@ describe("bin/builder-core", function () {
 
   describe("builder --version", function () {
 
-    it("runs version", stdioWrap(function (done) {
+    it("runs version", function (done) {
       base.sandbox.spy(Task.prototype, "version");
       base.mockFs({
         "package.json": "{}"
@@ -133,11 +112,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.version).to.be.calledOnce;
-        expect(process.stdout.write).to.be.calledWithMatch(pkg.version);
 
         done();
       });
-    }));
+    });
 
   });
 
@@ -252,7 +230,7 @@ describe("bin/builder-core", function () {
 
   describe("builder run", function () {
 
-    it("runs a <root>/package.json command", stdioWrap(function (done) {
+    it("runs a <root>/package.json command", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -268,14 +246,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stdout.write).to.be.calledWithMatch("BAR_TASK");
 
         done();
       });
 
-    }));
+    });
 
-    it("runs a with an unlimited buffer", stdioWrap(function (done) {
+    it("runs a with an unlimited buffer", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -291,14 +268,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stdout.write).to.be.calledWithMatch("BAR_TASK");
 
         done();
       });
 
-    }));
+    });
 
-    it("runs with quiet log output", stdioWrap(function (done) {
+    it("runs with quiet log output", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -314,17 +290,15 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stdout.write).to.be.calledWithMatch("BAR_TASK");
         expect(logStubs.info).not.be.called;
         expect(logStubs.warn).not.be.called;
         expect(logStubs.error).not.be.called;
 
         done();
       });
-    }));
+    });
 
-    it("runs with specified log level", stdioWrap(function (done) {
-      base.sandbox.stub(process.stderr, "write");
+    it("runs with specified log level", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -342,7 +316,6 @@ describe("bin/builder-core", function () {
           .that.contains("BAD_COMMAND");
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stderr.write).to.be.calledWithMatch("BAD_COMMAND");
         expect(logStubs.info).not.be.called;
         expect(logStubs.warn).not.be.called;
         expect(logStubs.error)
@@ -352,9 +325,9 @@ describe("bin/builder-core", function () {
         done();
       });
 
-    }));
+    });
 
-    it("runs an <archetype>/package.json command", stdioWrap(function (done) {
+    it("runs an <archetype>/package.json command", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -376,12 +349,11 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stdout.write).to.be.calledWithMatch("FOO_TASK");
 
         done();
       });
 
-    }));
+    });
 
     it("ignores archetype builder:-prefaced tasks", function () {
       base.mockFs({
@@ -414,7 +386,7 @@ describe("bin/builder-core", function () {
       throw new Error("should have already thrown");
     });
 
-    it("overrides a <archetype> command with a <root> one", stdioWrap(function (done) {
+    it("overrides a <archetype> command with a <root> one", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -440,12 +412,11 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stdout.write).to.be.calledWithMatch("ROOT_TASK");
 
         done();
       });
 
-    }));
+    });
 
     // TODO: This one is going to be... tough.
     // https://github.com/FormidableLabs/builder/issues/9
@@ -453,7 +424,7 @@ describe("bin/builder-core", function () {
 
     // TODO: Fix flake in --setup tests.
     // https://github.com/FormidableLabs/builder/issues/86
-    it.skip("runs with --setup", stdioWrap(function (done) {
+    it.skip("runs with --setup", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -471,19 +442,15 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(2);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("SETUP").and
-          .to.be.calledWithMatch("BAR_TASK").and
-          .to.be.calledWithMatch("EXIT - BAR_TASK - 0");
 
         done();
       });
 
-    }));
+    });
 
     // TODO: Fix flake in --setup tests.
     // https://github.com/FormidableLabs/builder/issues/86
-    it.skip("handles --setup early 0 exit", stdioWrap(function (done) {
+    it.skip("handles --setup early 0 exit", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -508,11 +475,11 @@ describe("bin/builder-core", function () {
         done();
       });
 
-    }));
+    });
 
     // TODO: Fix flake in --setup tests.
     // https://github.com/FormidableLabs/builder/issues/86
-    it.skip("handles --setup early 1 exit", stdioWrap(function (done) {
+    it.skip("handles --setup early 1 exit", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -537,10 +504,9 @@ describe("bin/builder-core", function () {
         done();
       });
 
-    }));
+    });
 
-    it("runs with --tries=2", stdioWrap(function (done) {
-      base.sandbox.stub(process.stderr, "write");
+    it("runs with --tries=2", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -558,7 +524,6 @@ describe("bin/builder-core", function () {
           .that.contains("BAD_COMMAND");
 
         expect(Task.prototype.run).to.be.calledOnce;
-        expect(process.stderr.write).to.be.calledWithMatch("BAD_COMMAND");
         expect(logStubs.warn).to.be.calledWithMatch(chalk.red("1") + " tries left");
         expect(logStubs.error)
           .to.be.calledWithMatch("Command failed").and
@@ -567,9 +532,9 @@ describe("bin/builder-core", function () {
         done();
       });
 
-    }));
+    });
 
-    it("runs with base config value", stdioWrap(function (done) {
+    it("runs with base config value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -588,14 +553,12 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from base config");
 
         done();
       });
-    }));
+    });
 
-    it("runs with archetype config value", stdioWrap(function (done) {
+    it("runs with archetype config value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -620,14 +583,12 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from archetype");
 
         done();
       });
-    }));
+    });
 
-    it("runs with empty base + non-empty archetype config value", stdioWrap(function (done) {
+    it("runs with empty base + non-empty archetype config value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -656,14 +617,12 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - EMPTY");
 
         done();
       });
-    }));
+    });
 
-    it("runs with real ENV overriding archetype config value", stdioWrap(function (done) {
+    it("runs with real ENV overriding archetype config value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -692,14 +651,12 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from real env");
 
         done();
       });
-    }));
+    });
 
-    it("runs with real ENV overriding base + archetype config values", stdioWrap(function (done) {
+    it("runs with real ENV overriding base + archetype config values", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -732,16 +689,14 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from real env");
 
         done();
       });
-    }));
+    });
 
     describe("expands paths with --expand-archetype", function () {
 
-      it("Skips `../node_modules/<archetype>`", stdioWrap(function (done) {
+      it("Skips `../node_modules/<archetype>`", function (done) {
         base.sandbox.spy(Task.prototype, "run");
         base.mockFs({
           ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -763,15 +718,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(process.stdout.write).to.be.calledWithMatch(
-            "WONT_EXPAND ../node_modules/mock-archetype/A_FILE.txt"
-          );
 
           done();
         });
-      }));
+      });
 
-      it("Skips `other/node_modules/<archetype>`", stdioWrap(function (done) {
+      it("Skips `other/node_modules/<archetype>`", function (done) {
         base.sandbox.spy(Task.prototype, "run");
         base.mockFs({
           ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -793,15 +745,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(process.stdout.write).to.be.calledWithMatch(
-            "WONT_EXPAND other/node_modules/mock-archetype/A_FILE.txt"
-          );
 
           done();
         });
-      }));
+      });
 
-      it("Replaces `node_modules/<archetype>`", stdioWrap(function (done) {
+      it("Replaces `node_modules/<archetype>`", function (done) {
         base.sandbox.spy(Task.prototype, "run");
         base.mockFs({
           ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -823,15 +772,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(process.stdout.write).to.be.calledWithMatch(
-            "EXPANDED " + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt")
-          );
 
           done();
         });
-      }));
+      });
 
-      it("Replaces `\"node_modules/<archetype>`", stdioWrap(function (done) {
+      it("Replaces `\"node_modules/<archetype>`", function (done) {
         base.sandbox.spy(Task.prototype, "run");
         base.mockFs({
           ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -855,15 +801,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(process.stdout.write).to.be.calledWithMatch(
-            "EXPANDED \"" + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt\"")
-          );
 
           done();
         });
-      }));
+      });
 
-      it("Propagates flag to sub-task", stdioWrap(function (done) {
+      it("Propagates flag to sub-task", function (done) {
         base.sandbox.spy(Task.prototype, "run");
         base.mockFs({
           ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -887,15 +830,12 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(process.stdout.write).to.be.calledWithMatch(
-            "EXPANDED " + path.join(process.cwd(), "node_modules/mock-archetype/A_FILE.txt")
-          );
 
           done();
         });
-      }));
+      });
 
-      it("Skips replacing root project tasks", stdioWrap(function (done) {
+      it("Skips replacing root project tasks", function (done) {
         base.sandbox.spy(Task.prototype, "run");
         base.mockFs({
           ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -917,13 +857,10 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
-          expect(process.stdout.write).to.be.calledWithMatch(
-            "WONT_EXPAND node_modules/mock-archetype/A_FILE.txt"
-          );
 
           done();
         });
-      }));
+      });
 
     });
 
@@ -931,7 +868,7 @@ describe("bin/builder-core", function () {
 
   describe("builder concurrent", function () {
 
-    it("runs <root>/package.json concurrent commands", stdioWrap(function (done) {
+    it("runs <root>/package.json concurrent commands", function (done) {
       base.sandbox.spy(Task.prototype, "concurrent");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -949,17 +886,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.concurrent).to.be.calledOnce;
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("ONE_TASK").and
-          .to.be.calledWithMatch("TWO_TASK").and
-          .to.be.calledWithMatch("THREE_TASK");
 
         done();
       });
 
-    }));
+    });
 
-    it("runs <archetype>/package.json concurrent commands", stdioWrap(function (done) {
+    it("runs <archetype>/package.json concurrent commands", function (done) {
       base.sandbox.spy(Task.prototype, "concurrent");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -988,15 +921,11 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.concurrent).to.be.calledOnce;
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("ONE_TASK").and
-          .to.be.calledWithMatch("TWO_ROOT_TASK").and
-          .to.be.calledWithMatch("THREE_ROOT_TASK");
 
         done();
       });
 
-    }));
+    });
 
     // TODO: Finish outlined tests.
     // https://github.com/FormidableLabs/builder/issues/9
@@ -1004,7 +933,7 @@ describe("bin/builder-core", function () {
     it("runs with --setup");
     it("runs with --queue=1, --bail=false");
 
-    it("runs with base overriding archetype config value", stdioWrap(function (done) {
+    it("runs with base overriding archetype config value", function (done) {
       base.sandbox.spy(Task.prototype, "concurrent");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -1036,19 +965,16 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.concurrent).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from base - ONE").and
-          .to.be.calledWithMatch("string - from base - TWO");
 
         done();
       });
-    }));
+    });
 
   });
 
   describe("builder envs", function () {
 
-    it("runs <root>/package.json multiple env commands", stdioWrap(function (done) {
+    it("runs <root>/package.json multiple env commands", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1068,17 +994,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("ROOT hi").and
-          .to.be.calledWithMatch("ROOT ho").and
-          .to.be.calledWithMatch("ROOT yo");
 
         done();
       });
 
-    }));
+    });
 
-    it("runs multiple env commands with --buffer, --envs-path", stdioWrap(function (done) {
+    it("runs multiple env commands with --buffer, --envs-path", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1099,17 +1021,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("ROOT hi").and
-          .to.be.calledWithMatch("ROOT ho").and
-          .to.be.calledWithMatch("ROOT yo");
 
         done();
       });
 
-    }));
+    });
 
-    it("runs <archetype>/package.json multiple env commands", stdioWrap(function (done) {
+    it("runs <archetype>/package.json multiple env commands", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -1135,17 +1053,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("ARCH hi").and
-          .to.be.calledWithMatch("ARCH ho").and
-          .to.be.calledWithMatch("ARCH yo");
 
         done();
       });
 
-    }));
+    });
 
-    it("overrides <archetype>/package.json multiple env commands", stdioWrap(function (done) {
+    it("overrides <archetype>/package.json multiple env commands", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -1175,17 +1089,13 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.be.calledOnce;
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("ROOT hi").and
-          .to.be.calledWithMatch("ROOT ho").and
-          .to.be.calledWithMatch("ROOT yo");
 
         done();
       });
 
-    }));
+    });
 
-    it("errors on empty JSON array", stdioWrap(function (done) {
+    it("errors on empty JSON array", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1205,9 +1115,9 @@ describe("bin/builder-core", function () {
         done();
       });
 
-    }));
+    });
 
-    it("errors on empty JSON non-array", stdioWrap(function (done) {
+    it("errors on empty JSON non-array", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1227,9 +1137,9 @@ describe("bin/builder-core", function () {
         done();
       });
 
-    }));
+    });
 
-    it("errors on malformed JSON array", stdioWrap(function (done) {
+    it("errors on malformed JSON array", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1251,9 +1161,9 @@ describe("bin/builder-core", function () {
 
         done();
       });
-    }));
+    });
 
-    it("errors on nonexistent JSON file", stdioWrap(function (done) {
+    it("errors on nonexistent JSON file", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1275,7 +1185,7 @@ describe("bin/builder-core", function () {
 
         done();
       });
-    }));
+    });
 
     // TODO: Finish outlined tests.
     // https://github.com/FormidableLabs/builder/issues/9
@@ -1283,7 +1193,7 @@ describe("bin/builder-core", function () {
     it("runs with --tries=2");
     it("runs with --queue=1, --bail=false");
 
-    it("runs with envs overriding base config value", stdioWrap(function (done) {
+    it("runs with envs overriding base config value", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -1306,16 +1216,12 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from base").and
-          .to.be.calledWithMatch("string - from array1").and
-          .to.be.calledWithMatch("string - from array2");
 
         done();
       });
-    }));
+    });
 
-    it("runs with envs real ENV overriding base + arch config value", stdioWrap(function (done) {
+    it("runs with envs real ENV overriding base + arch config value", function (done) {
       base.sandbox.spy(Task.prototype, "envs");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -1352,14 +1258,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.envs).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from real env").and
-          .to.be.calledWithMatch("string - from array1").and
-          .to.be.calledWithMatch("string - from array2");
 
         done();
       });
-    }));
+    });
 
   });
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -276,30 +276,6 @@ describe("bin/builder-core", function () {
 
     });
 
-    it("runs a with an unlimited buffer", function (done) {
-      base.sandbox.spy(Task.prototype, "run");
-      base.mockFs({
-        "package.json": JSON.stringify({
-          "scripts": {
-            "bar": "echo BAR_TASK >> stdout.log"
-          }
-        }, null, 2)
-      });
-
-      run({
-        argv: ["node", "builder", "run", "--unlimited-buffer", "bar"]
-      }, function (err) {
-        if (err) { return done(err); }
-
-        expect(Task.prototype.run).to.be.calledOnce;
-
-        readFile("stdout.log", function (data) {
-          expect(data).to.contain("BAR_TASK");
-        }, done);
-      });
-
-    });
-
     it("runs with quiet log output", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -25,7 +25,6 @@ describe("lib/args", function () {
         builderrc: ".builderrc",
         help: false,
         logLevel: "info",
-        unlimitedBuffer: false,
         quiet: false,
         version: false
       });
@@ -40,7 +39,6 @@ describe("lib/args", function () {
         builderrc: dummyPath,
         help: false,
         logLevel: "info",
-        unlimitedBuffer: false,
         quiet: false,
         version: false
       });

--- a/test/server/spec/lib/spawn.spec.js
+++ b/test/server/spec/lib/spawn.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var childProcess = require("child_process");
-var EventEmitter = require("events");
+var EventEmitter = require("events").EventEmitter;
 
 var spawn = require("../../../../lib/spawn");
 

--- a/test/server/spec/lib/spawn.spec.js
+++ b/test/server/spec/lib/spawn.spec.js
@@ -1,0 +1,53 @@
+"use strict";
+
+var childProcess = require("child_process");
+var EventEmitter = require("events");
+
+var spawn = require("../../../../lib/spawn");
+
+var base = require("../base.spec");
+
+describe("lib/spawn", function () {
+  beforeEach(function () {
+    base.sandbox.stub(childProcess, "spawn", function () {
+      var proc = new EventEmitter();
+      base.sandbox.spy(proc, "on");
+      return proc;
+    });
+  });
+
+  it("calls child_process.spawn", function () {
+    spawn("echo", ["hello"], {});
+    expect(childProcess.spawn).to.be.calledWithMatch("echo", ["hello"], {});
+  });
+
+  it("listens to error and close events", function () {
+    var proc = spawn("echo", ["hello"], {});
+    expect(proc.on).to.be.calledWith("error");
+    expect(proc.on).to.be.calledWith("close");
+  });
+
+  it("calls the given callback upon close", function () {
+    var callback = base.sandbox.spy();
+    var proc = spawn("echo", ["hello"], {}, callback);
+    proc.emit("close", 0, null);
+    expect(callback).to.be.calledWith(null);
+  });
+
+  it("passes error to the callback upon error", function () {
+    var callback = base.sandbox.spy();
+    var proc = spawn("echo", ["hello"], {}, callback);
+    proc.emit("error", { message: "uh-oh" });
+    expect(callback).to.not.be.called;
+    proc.emit("close", 0, null);
+    expect(callback).to.be.calledWithMatch({ message: "uh-oh" });
+  });
+
+  it("passes error to the callback upon non-zero exit", function () {
+    var callback = base.sandbox.spy();
+    var proc = spawn("echo", ["hello"], {}, callback);
+    expect(callback).to.not.be.called;
+    proc.emit("close", 1, null);
+    expect(callback).to.be.calledWithMatch({ code: 1 });
+  });
+});


### PR DESCRIPTION
This fixes the failing repro case from #120, but breaks the tests. If we go this route we need to rethink how we're capturing child process output in our tests, because stubbing `process.stdout.write` doesn't work anymore – a pretty major problem for our test suite.

The magic that makes it work is the `stdio: "inherit"` option to `spawn` (this is also what breaks the tests). AFAIK using anything but `"inherit"` won't work (I tried, and could still repro the issue).

This currently just makes the existing `buffer` option a no-op, but we could easily bring it back: if `buffer` is specified we'd switch off `stdio: "inherit"` and use `stdio: "pipe"` (the default) instead, buffering the output ourselves like `exec` would do.

Tasks:

* [x] Fix tests by finding a new way to capture stdout/stderr.
* [x] Bring back `buffer` option.
* [x] Test `spawn` edge cases.
* [x] Remove `--unlimited-buffer` option and tests.

Tickets:

* Need continued work to solve #120
* Fixes #20 