### PR TITLE
Unskip --setup tests to check flakiness

### DIFF
--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -467,7 +467,7 @@ describe("bin/builder-core", function () {
         "package.json": JSON.stringify({
           "scripts": {
             "setup": "node test/server/fixtures/repeat-script.js 2 SETUP",
-            "bar": "node test/server/fixtures/repeat-script.js 5 BAR_TASK"
+            "bar": "node test/server/fixtures/repeat-script.js 20 BAR_TASK"
           }
         }, null, 2)
       });
@@ -494,7 +494,7 @@ describe("bin/builder-core", function () {
         "package.json": JSON.stringify({
           "scripts": {
             "setup": "node test/server/fixtures/repeat-script.js 2 SETUP 1",
-            "bar": "node test/server/fixtures/repeat-script.js 10 BAR_TASK"
+            "bar": "node test/server/fixtures/repeat-script.js 20 BAR_TASK"
           }
         }, null, 2)
       });

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -432,9 +432,7 @@ describe("bin/builder-core", function () {
     // https://github.com/FormidableLabs/builder/issues/9
     it("overrides a <archetype> command with a <root> one in a composed <archetype> command");
 
-    // TODO: Fix flake in --setup tests.
-    // https://github.com/FormidableLabs/builder/issues/86
-    it.skip("runs with --setup", function (done) {
+    it("runs with --setup", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -463,9 +461,7 @@ describe("bin/builder-core", function () {
 
     });
 
-    // TODO: Fix flake in --setup tests.
-    // https://github.com/FormidableLabs/builder/issues/86
-    it.skip("handles --setup early 0 exit", function (done) {
+    it("handles --setup early 0 exit", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -492,9 +488,7 @@ describe("bin/builder-core", function () {
 
     });
 
-    // TODO: Fix flake in --setup tests.
-    // https://github.com/FormidableLabs/builder/issues/86
-    it.skip("handles --setup early 1 exit", function (done) {
+    it("handles --setup early 1 exit", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -467,7 +467,7 @@ describe("bin/builder-core", function () {
         "package.json": JSON.stringify({
           "scripts": {
             "setup": "node test/server/fixtures/repeat-script.js 2 SETUP",
-            "bar": "node test/server/fixtures/repeat-script.js 20 BAR_TASK"
+            "bar": "sleep 10"
           }
         }, null, 2)
       });
@@ -494,7 +494,7 @@ describe("bin/builder-core", function () {
         "package.json": JSON.stringify({
           "scripts": {
             "setup": "node test/server/fixtures/repeat-script.js 2 SETUP 1",
-            "bar": "node test/server/fixtures/repeat-script.js 20 BAR_TASK"
+            "bar": "sleep 10"
           }
         }, null, 2)
       });


### PR DESCRIPTION
Now that we use `spawn` and have a new method of capturing stdio in tests, let's unskip the `--setup` tests. (They haven't flaked on me yet, but we can try triggering CI multiple times if it was only happening rarely.)

Fixes #86.

/cc @ryan-roemer