### PR TITLE
Exit when the process is ready and has flushed stdout

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@ History
   [#20](https://github.com/FormidableLabs/builder/issues/20)
 * Add auto-TOC to README.md.
   [#101](https://github.com/FormidableLabs/builder/issues/101)
+* Use a "safe exit" pattern to avoid immediately exiting the `builder` process
+  when there is potentially unflushed output.
+  [#124](https://github.com/FormidableLabs/builder/issues/124)
 
 ## 2.10.1
 

--- a/bin/builder.js
+++ b/bin/builder.js
@@ -43,6 +43,8 @@ var builder = require(builderPath);
 builder({
   msgs: msgs
 }, function (err) {
-  /*eslint-disable no-process-exit*/
-  process.exit(err ? err.code || 1 : 0);
+  process.on("exit", function () {
+    /*eslint-disable no-process-exit*/
+    process.exit(err ? err.code || 1 : 0);
+  });
 });


### PR DESCRIPTION
Use the "safe exit" pattern from https://github.com/nodejs/node-v0.x-archive/issues/3737 to exit with our return code when the process is naturally ready. This will prevent any pending piped output [edit: from *us*, in case some other process is running `builder`] from being truncated.

Fixes #124.