### PR TITLE
Default log level to `none` for `help` and `version` commands. 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,8 +3,15 @@ History
 
 ## Unreleased
 
-* **BREAKING**: Remove `--unlimited-buffer` command line option. It is unneeded
-  with switch to `spawn`.
+**BREAKING**:
+
+* Remove `--unlimited-buffer` command line option. It is unneeded with switch to
+  `spawn`.
+
+Other:
+
+* Default log level to `none` for `help` and `version` commands.
+  [#127](https://github.com/FormidableLabs/builder/issues/127)
 * Switch from `exec` to `spawn` child process spawning for better stdio/stderr
   propagation. ( [@exogen][] )
   [#20](https://github.com/FormidableLabs/builder/issues/20)

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,4 +1,5 @@
 "use strict";
+/*eslint max-statements:[2, 20]*/
 
 /**
  * Argv command flags.
@@ -156,6 +157,9 @@ var createFn = function (flags) {
     // Parse.
     var parsedOpts = nopt(opts, {}, argv);
 
+    // Stash if log-level was actually set.
+    var logLevel = parsedOpts["log-level"];
+
     // Inject defaults and mutate parsed object.
     _.extend(parsedOpts, _.mapValues(flags, function (val, key) {
       var parsedVal = parsedOpts[key];
@@ -166,6 +170,21 @@ var createFn = function (flags) {
 
       return _.isUndefined(parsedVal) ? val.default : parsedVal;
     }));
+
+    // Update options for _command_ of `help`, `` (nothing = help), `version`
+    if (parsedOpts.argv.remain[0] === "version") {
+      parsedOpts.version = true;
+    }
+    if (!parsedOpts.version &&
+      (parsedOpts.argv.remain.length === 0 || parsedOpts.argv.remain[0] === "help")) {
+      parsedOpts.help = true;
+    }
+
+    // If `help` or `version`, silence log if not explicitly set.
+    // https://github.com/FormidableLabs/builder/issues/127
+    if ((parsedOpts.help || parsedOpts.version) && !logLevel) {
+      parsedOpts["log-level"] = "none";
+    }
 
     return _(parsedOpts)
       // Camel-case flags.

--- a/lib/log.js
+++ b/lib/log.js
@@ -62,7 +62,9 @@ var log = module.exports = {
 
   // Nuke everything for test runs.
   _unsetLevel: function () {
-    delete log._env._BUILDER_ARGS_LOG_LEVEL;
+    if (log._env) {
+      delete log._env._BUILDER_ARGS_LOG_LEVEL;
+    }
     delete log._level;
     delete log._queue;
   },

--- a/lib/task.js
+++ b/lib/task.js
@@ -176,13 +176,14 @@ Task.prototype.help = function (callback) {
   // Display task configs if we have _some_.
   var taskConfigs = this._config.displayConfigs(archetypes);
 
-  log.info("help",
-    "\n\n" + chalk.green.bold("Usage") + ": \n\n  builder " + actionDisplay + " <task(s)>" +
+  // Use raw stdout instead of logger so we can disable logger on "help".
+  process.stdout.write(
+    chalk.green.bold("Usage") + ": \n\n  builder " + actionDisplay + " <task(s)>" +
     "\n\n" + chalk.green.bold("Actions") + ": \n\n  " + actions +
     "\n\n" + flagsDisplay + ": General\n\n  " + args.help() +
     actionFlags +
     (taskConfigs ? "\n\n" + chalk.green.bold("Task Configs") + ": \n" + taskConfigs : "") +
-    "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts(archetypes));
+    "\n\n" + chalk.green.bold("Tasks") + ": \n" + this._config.displayScripts(archetypes) + "\n");
 
   callback();
 };

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -23,8 +23,8 @@ describe("lib/args", function () {
     it("handles defaults for general flags", function () {
       expect(_flags(args.general(argv))).to.deep.equal({
         builderrc: ".builderrc",
-        help: false,
-        logLevel: "info",
+        help: true,
+        logLevel: "none",
         quiet: false,
         version: false
       });
@@ -37,8 +37,8 @@ describe("lib/args", function () {
 
       expect(_flags(args.general(argv))).to.deep.equal({
         builderrc: dummyPath,
-        help: false,
-        logLevel: "info",
+        help: true,
+        logLevel: "none",
         quiet: false,
         version: false
       });
@@ -54,6 +54,8 @@ describe("lib/args", function () {
 
     it("handles defaults for run flags", function () {
       expect(_flags(args.run(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 1,
         expandArchetype: false,
         setup: null
@@ -63,6 +65,8 @@ describe("lib/args", function () {
     it("handles valid --tries", function () {
       argv = argv.concat(["--tries=2"]);
       expect(_flags(args.run(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 2,
         expandArchetype: false,
         setup: null
@@ -73,18 +77,24 @@ describe("lib/args", function () {
       // Invalid tries default to `1`.
 
       expect(_flags(args.run(argv.concat(["--tries=-1"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 1,
         expandArchetype: false,
         setup: null
       });
 
       expect(_flags(args.run(argv.concat(["--tries=BAD"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 1,
         expandArchetype: false,
         setup: null
       });
 
       expect(_flags(args.run(argv.concat(["--tries="])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 1,
         expandArchetype: false,
         setup: null
@@ -94,6 +104,8 @@ describe("lib/args", function () {
     it("handles valid --setup", function () {
       argv = argv.concat(["--setup=foo"]);
       expect(_flags(args.run(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 1,
         expandArchetype: false,
         setup: "foo"
@@ -103,6 +115,8 @@ describe("lib/args", function () {
     it("handles invalid --setup", function () {
       argv = argv.concat(["--setup="]);
       expect(_flags(args.run(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         tries: 1,
         expandArchetype: false,
         setup: null
@@ -115,6 +129,8 @@ describe("lib/args", function () {
 
     it("handles defaults for concurrent flags", function () {
       expect(_flags(args.concurrent(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -127,6 +143,8 @@ describe("lib/args", function () {
     it("handles valid --tries, --queue, --buffer, --no-bail", function () {
       argv = argv.concat(["--tries=2", "--queue=2", "--buffer", "--no-bail"]);
       expect(_flags(args.concurrent(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: 2,
         buffer: true,
         tries: 2,
@@ -138,6 +156,8 @@ describe("lib/args", function () {
 
     it("handles valid --buffer", function () {
       expect(_flags(args.concurrent(argv.concat(["--buffer"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: true,
         tries: 1,
@@ -147,6 +167,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--no-buffer"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -156,6 +178,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--buffer=false"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -165,6 +189,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--buffer=true"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: true,
         tries: 1,
@@ -173,7 +199,9 @@ describe("lib/args", function () {
         bail: true
       });
 
-      expect(_flags(args.concurrent(argv.concat(["--buffer=1"])))).to.deep.equal({
+      expect(_flags(args.concurrent(argv.concat(["--buffer"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: true,
         tries: 1,
@@ -185,6 +213,8 @@ describe("lib/args", function () {
 
     it("handles valid --bail", function () {
       expect(_flags(args.concurrent(argv.concat(["--bail"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -194,6 +224,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--no-bail"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -203,6 +235,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--bail=false"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -212,6 +246,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--bail=true"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -220,7 +256,9 @@ describe("lib/args", function () {
         bail: true
       });
 
-      expect(_flags(args.concurrent(argv.concat(["--bail=1"])))).to.deep.equal({
+      expect(_flags(args.concurrent(argv.concat(["--bail"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -233,6 +271,8 @@ describe("lib/args", function () {
     it("handles invalid --tries", function () {
       // Invalid tries default to `1`.
       expect(_flags(args.concurrent(argv.concat(["--tries=-1"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -242,6 +282,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--tries=BAD", "--queue=2"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: 2,
         buffer: false,
         tries: 1,
@@ -251,6 +293,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--tries="])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -263,6 +307,8 @@ describe("lib/args", function () {
     it("handles invalid --queue", function () {
       // Invalid queue defaults to `null`.
       expect(_flags(args.concurrent(argv.concat(["--queue=-1"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -272,6 +318,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--queue=BAD", "--tries=2"])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 2,
@@ -281,6 +329,8 @@ describe("lib/args", function () {
       });
 
       expect(_flags(args.concurrent(argv.concat(["--queue="])))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -293,6 +343,8 @@ describe("lib/args", function () {
     it("handles multiple flags", function () {
       var flags = ["--queue=-1", "--tries=BAD", "--no-buffer", "--no-bail"];
       expect(_flags(args.concurrent(argv.concat(flags)))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         buffer: false,
         tries: 1,
@@ -309,6 +361,8 @@ describe("lib/args", function () {
 
     it("handles defaults for envs flags", function () {
       expect(_flags(args.envs(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         envsPath: null,
         buffer: false,
@@ -324,6 +378,8 @@ describe("lib/args", function () {
       var dummyPath = path.join(__dirname, "DUMMY_ENVS.json");
       argv = argv.concat(["--tries=2", "--queue=2", "--buffer", "--envs-path=" + dummyPath]);
       expect(_flags(args.envs(argv))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: 2,
         envsPath: dummyPath,
         buffer: true,
@@ -337,6 +393,8 @@ describe("lib/args", function () {
     it("handles multiple flags", function () {
       var flags = ["--queue=-1", "--tries=BAD", "--no-buffer"];
       expect(_flags(args.envs(argv.concat(flags)))).to.deep.equal({
+        help: true,
+        logLevel: "none",
         queue: null,
         envsPath: null,
         buffer: false,


### PR DESCRIPTION
* Default log level to `none` for `help` and `version` commands. Fixes #127
* Minor HISTORY.md cleanup

/cc @exogen 