### PR TITLE
Feature: `--env`, `--env-path` flags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.2"
-  - "5.7"
+  - "4"
+  - "5"
+  - "6"
 
 # Use container-based Travis infrastructure.
 sudo: false

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## Unreleased
+
+* Add `--env` environment variable flag.
+  [#45](https://github.com/FormidableLabs/builder/issues/45)
+
 ## 3.0.0
 
 **BREAKING**:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ the rough goals and motivations behind the project.
       - [builder run](#builder-run)
       - [builder concurrent](#builder-concurrent)
       - [builder envs](#builder-envs)
-        - [Custom Flags](#custom-flags)
-        - [Expanding the Archetype Path](#expanding-the-archetype-path)
+    - [Custom Flags](#custom-flags)
+    - [Expanding the Archetype Path](#expanding-the-archetype-path)
 - [Tasks](#tasks)
 - [npm Config](#npm-config)
   - [`npm` Config Overview](#npm-config-overview)
@@ -356,7 +356,7 @@ _Note_: The environments JSON array will overwrite **existing** values in the
 environment. This includes environment variables provided to / from `builder`
 from things such as `npm` `config` and the `--env`/`--env-path` flags.
 
-###### Custom Flags
+#### Custom Flags
 
 Just like [`npm run <task> [-- <args>...]`](https://docs.npmjs.com/cli/run-script),
 flags after a ` -- ` token in a builder task or from the command line are passed
@@ -398,7 +398,7 @@ The rough heuristic here is if we have custom arguments:
    environment variables. (Builder uses `_BUILDER_ARGS_CUSTOM_FLAGS`).
 2. If a non-`builder` command, then append without ` -- ` token.
 
-###### Expanding the Archetype Path
+#### Expanding the Archetype Path
 
 Builder tasks often refer to configuration files in the archetype itself like:
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,16 @@ _Note_: The environments JSON array will overwrite **existing** values in the
 environment. This includes environment variables provided to / from `builder`
 from things such as `npm` `config` and the `--env`/`--env-path` flags.
 
+So, for example, if you invoke `builder` with:
+
+```js
+$ builder envs <task> '[{"FOO": "ENVS"}]' --env='{"FOO": "FLAG"}'
+```
+
+The environment variable `FOO` will have a value of `"ENVS"` with the single
+environment object array item given to `builder envs` overriding the `--env`
+flag value.
+
 #### Custom Flags
 
 Just like [`npm run <task> [-- <args>...]`](https://docs.npmjs.com/cli/run-script),

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Flags:
 * `--setup`: Single task to run for the entirety of `<action>`
 * `--quiet`: Silence logging
 * `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
+* `--env`: JSON object of keys to add to environment.
+* `--env-path`: JSON file path of keys to add to environment.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 
@@ -301,6 +303,8 @@ Flags:
 * `--[no-]bail`: End all processes after the first failure (default: `true`)
 * `--quiet`: Silence logging
 * `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
+* `--env`: JSON object of keys to add to environment.
+* `--env-path`: JSON file path of keys to add to environment.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 
@@ -343,11 +347,14 @@ Flags:
 * `--envs-path`: Path to JSON env variable array file (default: `null`)
 * `--quiet`: Silence logging
 * `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
+* `--env`: JSON object of keys to add to environment.
+* `--env-path`: JSON file path of keys to add to environment.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
 * `--builderrc`: Path to builder config file (default: `.builderrc`)
 
 _Note_: The environments JSON array will overwrite **existing** values in the
-environment.
+environment. This includes environment variables provided to / from `builder`
+from things such as `npm` `config` and the `--env`/`--env-path` flags.
 
 ###### Custom Flags
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: 0.12
     - nodejs_version: 4
     - nodejs_version: 5
+    - nodejs_version: 6
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -20,8 +21,11 @@ test_script:
   # Output useful info for debugging.
   - node --version
   - node_modules\.bin\npm --version
-  # run tests
-  - node_modules\.bin\npm run builder:check
+  # TODO REENABLE
+  # # run tests
+  # - node_modules\.bin\npm run builder:check
+  # TODO REMOVE
+  - node_modules\.bin\npm run builder:test
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,11 +21,8 @@ test_script:
   # Output useful info for debugging.
   - node --version
   - node_modules\.bin\npm --version
-  # TODO REENABLE
-  # # run tests
-  # - node_modules\.bin\npm run builder:check
-  # TODO REMOVE
-  - node_modules\.bin\npm run builder:test
+  # run tests
+  - node_modules\.bin\npm run builder:check
 
 # Don't actually build.
 build: off

--- a/bin/builder-core.js
+++ b/bin/builder-core.js
@@ -28,7 +28,8 @@ module.exports = function (opts, callback) {
   // Set up environment
   var env = new Environment({
     config: config,
-    env: opts.env
+    env: opts.env,
+    argv: opts.argv
   });
 
   // Set up logger state.

--- a/lib/args.js
+++ b/lib/args.js
@@ -72,6 +72,16 @@ var FLAGS = {
       desc: "Level to log at (`info`, `warn`, `error`, `none`)",
       types: [String],
       default: "info"
+    },
+    env: {
+      desc: "JSON string of environment variables to add to process",
+      types: [String],
+      default: null
+    },
+    "env-path": {
+      desc: "JSON file path of environment variables to add to process",
+      types: [path],
+      default: null
     }
   },
 
@@ -98,7 +108,7 @@ var FLAGS = {
     buffer: FLAG_BUFFER,
     bail: FLAG_BAIL,
     "envs-path": {
-      desc: "Path to JSON env variable array file (default: `null`)",
+      desc: "JSON File path to `envs` array",
       types: [path],
       default: null
     }

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -156,9 +156,7 @@ Environment.prototype.updateEnvFlag = function (opts) {
   });
 
   // Validation
-  if (_.isEmpty(envsObj)) {
-    throw new Error("Empty/null JSON environment.");
-  } else if (!_.isPlainObject(envsObj)) {
+  if (!_.isPlainObject(envsObj)) {
     throw new Error("Non-object JSON environment: " + JSON.stringify(envsObj));
   }
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -32,6 +32,7 @@ var CWD_NODE_PATH = path.join(process.cwd(), "node_modules");
 var Environment = module.exports = function (opts) {
   opts = opts || {};
   this.config = opts.config;
+  this.argv = opts.argv || process.argv;
 
   // Clone if real process env to avoid direct mutation.
   this.env = opts.env || process.env;
@@ -53,6 +54,9 @@ var Environment = module.exports = function (opts) {
 
   // Add in npm config environment variables.
   this.updateConfigVars(this.config.pkgConfigs);
+
+  // Add command-line `--env|--env-path` overrides.
+  // TODO: HERE
 };
 
 /**

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -162,6 +162,11 @@ Environment.prototype.updateEnvFlag = function (opts) {
     throw new Error("Non-object JSON environment: " + JSON.stringify(envsObj));
   }
 
+  // TODO: TEMP REMOVE - Debugging appveyor
+  console.error("TODO HERE - this.env", JSON.stringify(this.env, null, 2));
+  console.error("TODO HERE - envsObj", JSON.stringify(envsObj, null, 2));
+  console.error("TODO HERE - merged", JSON.stringify(_.merge(this.env, envsObj), null, 2));
+
   // Mutate environment and return.
   return _.merge(this.env, envsObj);
 };

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -162,11 +162,6 @@ Environment.prototype.updateEnvFlag = function (opts) {
     throw new Error("Non-object JSON environment: " + JSON.stringify(envsObj));
   }
 
-  // TODO: TEMP REMOVE - Debugging appveyor
-  console.error("TODO HERE - this.env", JSON.stringify(this.env, null, 2));
-  console.error("TODO HERE - envsObj", JSON.stringify(envsObj, null, 2));
-  console.error("TODO HERE - merged", JSON.stringify(_.merge(this.env, envsObj), null, 2));
-
   // Mutate environment and return.
   return _.merge(this.env, envsObj);
 };

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -8,7 +8,9 @@
  */
 var _ = require("lodash");
 var path = require("path");
+var args = require("./args");
 var clone = require("./utils/clone");
+var jsonParse = require("./utils/json").parse;
 
 // OS-specific helpers
 var IS_WIN = process.platform.indexOf("win") === 0;
@@ -32,7 +34,10 @@ var CWD_NODE_PATH = path.join(process.cwd(), "node_modules");
 var Environment = module.exports = function (opts) {
   opts = opts || {};
   this.config = opts.config;
+
+  // Arguments
   this.argv = opts.argv || process.argv;
+  var parsed = args.general(this.argv);
 
   // Clone if real process env to avoid direct mutation.
   this.env = opts.env || process.env;
@@ -55,8 +60,8 @@ var Environment = module.exports = function (opts) {
   // Add in npm config environment variables.
   this.updateConfigVars(this.config.pkgConfigs);
 
-  // Add command-line `--env|--env-path` overrides.
-  // TODO: HERE
+  // Add command-line `--env|--env-path` environment overrides.
+  this.updateEnvFlag(parsed);
 };
 
 /**
@@ -128,4 +133,35 @@ Environment.prototype.updateConfigVars = function (pkgConfigs) {
   });
 
   return this.env;
+};
+
+/**
+ * Update environment `--env` / `--env-path` command line options.
+ *
+ * @param   {Object}  opts          Options
+ * @param   {String}  opts.env      Stringified JSON object
+ * @param   {String}  opts.envPath  Path to JSON file
+ * @returns {Object}                Mutated environment variable.
+ */
+Environment.prototype.updateEnvFlag = function (opts) {
+  // Nothing to parse.
+  if (!(opts.env || opts.envPath)) {
+    return this.env;
+  }
+
+  // Parse envs.
+  var envsObj = jsonParse({
+    str: opts.env,
+    path: opts.envPath
+  });
+
+  // Validation
+  if (_.isEmpty(envsObj)) {
+    throw new Error("Empty/null JSON environment.");
+  } else if (!_.isPlainObject(envsObj)) {
+    throw new Error("Non-object JSON environment: " + JSON.stringify(envsObj));
+  }
+
+  // Mutate environment and return.
+  return _.merge(this.env, envsObj);
 };

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var fs = require("fs");
 var path = require("path");
 var _ = require("lodash");
 var chalk = require("chalk");
 var args = require("./args");
 var Environment = require("./environment");
 var log = require("./log");
+var jsonParse = require("./utils/json").parse;
 
 /**
  * Task wrapper.
@@ -248,24 +248,6 @@ Task.prototype.concurrent = function (callback) {
     { env: env }, opts, callback);
 };
 
-Task.prototype._parseJson = function (objStr) {
-  try {
-    return JSON.parse(objStr);
-  } catch (err) {
-    log.error(this._action + ":json-obj", "Failed to load JSON object: " + objStr);
-    throw err;
-  }
-};
-
-Task.prototype._parseJsonFile = function (filePath) {
-  try {
-    return JSON.parse(fs.readFileSync(filePath));
-  } catch (err) {
-    log.error(this._action + ":json-file", "Failed to load JSON file: " + filePath);
-    throw err;
-  }
-};
-
 /**
  * Run multiple environments.
  *
@@ -280,35 +262,35 @@ Task.prototype.envs = function (callback) {
   var flags = args.envs(this.argv);
   var opts = this.getOpts(task, flags);
 
-  // Get task environment array.
-  var envsStr = this._commands[1];
+  // Parse envs.
+  var envsObj;
+  var err;
   try {
-    if (envsStr) {
-      // Try string on command line first:
-      // $ builder envs <task> '[{ "FOO": "VAL1" }, { "FOO": "VAL2" }]'
-      opts._envs = this._parseJson(envsStr);
-    } else if (opts.envsPath) {
-      // Try JSON file path next:
-      // $ builder envs <task> --envs-path=my-environment-vars.json
-      opts._envs = this._parseJsonFile(opts.envsPath);
-    }
+    envsObj = jsonParse({
+      str: this._commands[1], // Get task environment array.
+      path: opts.envsPath
+    });
   } catch (parseErr) {
-    return callback(parseErr);
+    err = parseErr;
   }
 
   // Validation
-  var err;
-  if (_.isEmpty(opts._envs)) {
+  if (!err && _.isEmpty(envsObj)) {
     err = new Error("Empty/null JSON environments array.");
-  } else if (!_.isArray(opts._envs)) {
-    err = new Error("Non-array JSON environments object: " + JSON.stringify(opts._envs));
+  } else if (!err && !_.isArray(envsObj)) {
+    err = new Error("Non-array JSON environments object: " + JSON.stringify(envsObj));
   }
 
   if (err) {
-    log.error("envs:json-error", err);
+    log.error(this._action + ":json-error",
+      "Failed to load environments string / path with error: " + err);
     return callback(err);
   }
 
+  // Stash for use in runner options.
+  opts._envs = envsObj;
+
+  // Run.
   this._runner.envs(task.cmd, { env: env }, opts, callback);
 };
 

--- a/lib/utils/json.js
+++ b/lib/utils/json.js
@@ -1,0 +1,48 @@
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+var _ = require("lodash");
+
+/**
+ * Parse environment string and/or JSON file path into a full JS object.
+ *
+ * For use with environment variable specification.
+ *
+ * **Note**: Does synchronous file read.
+ *
+ * Parsing logic:
+ *
+ * 1. Try `opts.str` string if set
+ * 2. If not, try `opts.path` file
+ *
+ * @param {Object}    opts        Options
+ * @param {String}    opts.str    Stringified JSON object
+ * @param {String}    opts.path   Path to JSON file
+ * @returns {Object}              Data object.
+ */
+module.exports = {
+  parse: function (opts) {
+    var jsonStr = _.isUndefined(opts.str) ? null : opts.str;
+    var jsonPath = _.isUndefined(opts.path) ? null : opts.path;
+
+    // Validation: Programming error if thrown.
+    if (jsonStr === null && jsonPath === null) {
+      throw new Error("Must specify JSON string or path.");
+    }
+
+    // Try string first.
+    if (jsonStr) {
+      return JSON.parse(jsonStr);
+    }
+
+    // Try JSON file path next.
+    if (jsonPath) {
+      var data = fs.readFileSync(path.resolve(jsonPath));
+      return JSON.parse(data);
+    }
+
+    // Programming error.
+    throw new Error("Invalid parsing path.");
+  }
+};

--- a/test/server/fixtures/echo.js
+++ b/test/server/fixtures/echo.js
@@ -28,6 +28,8 @@ if (typeof msg === "undefined") {
   msg = process.env.TEST_MESSAGE;
 }
 
+console.error("TODO HERE ECHO", JSON.stringify(process.env, null, 2));
+
 var extra = process.argv[2] || "";
 var out = typeof msg + " - " + (msg || "EMPTY") + (extra ? " - " + extra : "");
 

--- a/test/server/fixtures/echo.js
+++ b/test/server/fixtures/echo.js
@@ -19,8 +19,16 @@
  *   }
  * }
  * ```
+ *
+ * Secondarily falls back on real environment variable `TEST_MESSAGE` if above
+ * is not set.
  */
 var msg = process.env.npm_package_config__test_message;
+if (typeof msg === "undefined") {
+  msg = process.env.TEST_MESSAGE;
+}
+
 var extra = process.argv[2] || "";
 var out = typeof msg + " - " + (msg || "EMPTY") + (extra ? " - " + extra : "");
+
 process.stdout.write(out + "\n");

--- a/test/server/fixtures/echo.js
+++ b/test/server/fixtures/echo.js
@@ -28,8 +28,6 @@ if (typeof msg === "undefined") {
   msg = process.env.TEST_MESSAGE;
 }
 
-console.error("TODO HERE ECHO", JSON.stringify(process.env, null, 2));
-
 var extra = process.argv[2] || "";
 var out = typeof msg + " - " + (msg || "EMPTY") + (extra ? " - " + extra : "");
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -158,13 +158,88 @@ describe("bin/builder-core", function () {
       throw new Error("should have already thrown");
     });
 
-    // TODO: IMPLEMENT
-    it("errors on empty --env value");
-    it("errors on non-JSON --env value");
-    it("errors on non-Object --env value");
-    it("errors on empty --env-path value");
-    it("errors on non-JSON --env-path value");
-    it("errors on non-Object --env-path value");
+    it("errors on non-JSON --env value", function () {
+      base.mockFs({
+        "package.json": "{}"
+      });
+
+      var callback = base.sandbox.spy();
+
+      try {
+        run({
+          argv: ["node", "builder", "help", "--env=bad_value"]
+        }, callback);
+      } catch (err) {
+        expect(err).to.have.property("message").that.contains("Unexpected token");
+        expect(callback).to.not.be.called;
+        return;
+      }
+
+      throw new Error("should have already thrown");
+    });
+
+    it("errors on non-Object --env value", function () {
+      base.mockFs({
+        "package.json": "{}"
+      });
+
+      var callback = base.sandbox.spy();
+
+      try {
+        run({
+          argv: ["node", "builder", "help", "--env=[{\"foo\":42}]"]
+        }, callback);
+      } catch (err) {
+        expect(err).to.have.property("message").that.contains("Non-object JSON environment");
+        expect(callback).to.not.be.called;
+        return;
+      }
+
+      throw new Error("should have already thrown");
+    });
+
+    it("errors on non-JSON --env-path value", function () {
+      base.mockFs({
+        "package.json": "{}",
+        "env.json": "NOT_JSON"
+      });
+
+      var callback = base.sandbox.spy();
+
+      try {
+        run({
+          argv: ["node", "builder", "help", "--env-path=env.json"]
+        }, callback);
+      } catch (err) {
+        expect(err).to.have.property("message").that.contains("Unexpected token");
+        expect(callback).to.not.be.called;
+        return;
+      }
+
+      throw new Error("should have already thrown");
+    });
+
+    it("errors on non-Object --env-path value", function () {
+      base.mockFs({
+        "package.json": "{}",
+        "env.json": JSON.stringify([{ "foo": 42 }], null, 2)
+      });
+
+      var callback = base.sandbox.spy();
+
+      try {
+        run({
+          argv: ["node", "builder", "help", "--env-path=env.json"]
+        }, callback);
+      } catch (err) {
+        expect(err).to.have.property("message").that.contains("Non-object JSON environmen");
+        expect(callback).to.not.be.called;
+        return;
+      }
+
+      throw new Error("should have already thrown");
+    });
+
   });
 
   describe("builder --version", function () {

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -706,9 +706,12 @@ describe("bin/builder-core", function () {
 
         expect(Task.prototype.run).to.have.callCount(1);
 
-        readFile("stdout.log", function (data) {
-          expect(data).to.contain("string - EMPTY");
-        }, done);
+        // TODO: REVERT
+        done();
+
+        // readFile("stdout.log", function (data) {
+        //   expect(data).to.contain("string - EMPTY");
+        // }, done);
       });
     });
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -557,6 +557,30 @@ describe("bin/builder-core", function () {
 
     });
 
+    // TODO: HERE
+    it.skip("runs with --env value", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "node test/server/fixtures/echo.js"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "echo", "--env='{\"TEST_MESSAGE\":\"HI\"}'"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.have.callCount(1);
+        expect(process.stdout.write)
+          .to.be.calledWithMatch("string - from base config");
+
+        done();
+      });
+    }));
+
     it("runs with --tries=2", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
@@ -1279,7 +1303,7 @@ describe("bin/builder-core", function () {
           .that.contains("Unexpected token");
 
         expect(logStubs.error)
-          .to.be.calledWithMatch("Failed to load JSON object");
+          .to.be.calledWithMatch("load environments string / path with error: SyntaxError");
 
         done();
       });
@@ -1303,7 +1327,7 @@ describe("bin/builder-core", function () {
           .that.contains("ENOENT");
 
         expect(logStubs.error)
-          .to.be.calledWithMatch("Failed to load JSON file");
+          .to.be.calledWithMatch("load environments string / path with error: Error: ENOENT");
 
         done();
       });

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -694,7 +694,7 @@ describe("bin/builder-core", function () {
       base.mockFs({
         "package.json": JSON.stringify({
           "scripts": {
-            "echo": "node test/server/fixtures/echo.js >> stdout.log"
+            "echo": "node test/server/fixtures/echo.js" // TODO RENABLE >> stdout.log"
           }
         }, null, 2)
       });

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -863,8 +863,7 @@ describe("bin/builder-core", function () {
       });
     });
 
-    // TODO: Implement
-    it.skip("runs with --env overriding base + archetype config values", function (done) {
+    it("runs with --env overriding base + archetype config values", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         ".builderrc": "---\narchetypes:\n  - mock-archetype",
@@ -889,7 +888,7 @@ describe("bin/builder-core", function () {
 
       run({
         argv: ["node", "builder", "run", "echo",
-          "--env='{\"npm_package_config__test_message\":\"from real env\"}'"]
+          "--env={\"npm_package_config__test_message\":\"from real env\"}"]
       }, function (err) {
         if (err) { return done(err); }
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -581,6 +581,30 @@ describe("bin/builder-core", function () {
       });
     }));
 
+    // TODO: IMPLEMENT
+    it.skip("runs with empty string --env value", stdioWrap(function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "node test/server/fixtures/echo.js >> stdout.log"
+          }
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "echo", "--env='{\"TEST_MESSAGE\":\"\"}'"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.have.callCount(1);
+
+        readFile("stdout.log", function (data) {
+          expect(data).to.contain("string - EMPTY");
+        }, done);
+      });
+    }));
+
     it("runs with --tries=2", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
@@ -770,6 +794,44 @@ describe("bin/builder-core", function () {
 
       run({
         argv: ["node", "builder", "run", "echo"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.have.callCount(1);
+
+        readFile("stdout.log", function (data) {
+          expect(data).to.contain("string - from real env");
+        }, done);
+      });
+    });
+
+    // TODO: Implement
+    it.skip("runs with --env overriding base + archetype config values", function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        ".builderrc": "---\narchetypes:\n  - mock-archetype",
+        "package.json": JSON.stringify({
+          "config": {
+            "_test_message": "from base"
+          }
+        }, null, 2),
+        "node_modules": {
+          "mock-archetype": {
+            "package.json": JSON.stringify({
+              "config": {
+                "_test_message": "from archetype"
+              },
+              "scripts": {
+                "echo": "node test/server/fixtures/echo.js >> stdout.log"
+              }
+            }, null, 2)
+          }
+        }
+      });
+
+      run({
+        argv: ["node", "builder", "run", "echo",
+          "--env='{\"npm_package_config__test_message\":\"from real env\"}'"]
       }, function (err) {
         if (err) { return done(err); }
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -563,7 +563,7 @@ describe("bin/builder-core", function () {
       base.mockFs({
         "package.json": JSON.stringify({
           "scripts": {
-            "echo": "node test/server/fixtures/echo.js"
+            "echo": "node test/server/fixtures/echo.js >> stdout.log"
           }
         }, null, 2)
       });
@@ -574,10 +574,10 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.have.callCount(1);
-        expect(process.stdout.write)
-          .to.be.calledWithMatch("string - from base config");
 
-        done();
+        readFile("stdout.log", function (data) {
+          expect(data).to.contain("string - HI");
+        }, done);
       });
     }));
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -565,7 +565,7 @@ describe("bin/builder-core", function () {
 
     });
 
-    it("runs with --env value", stdioWrap(function (done) {
+    it("runs with --env value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -586,13 +586,35 @@ describe("bin/builder-core", function () {
           expect(data).to.contain("string - HI");
         }, done);
       });
-    }));
+    });
 
-    // TODO: IMPLEMENT
-    it("TODO: runs with --env-path value");
+    it("runs with --env-path value", function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "node test/server/fixtures/echo.js >> stdout.log"
+          }
+        }, null, 2),
+        "env.json": JSON.stringify({
+          "TEST_MESSAGE": "FROM FILE"
+        }, null, 2)
+      });
 
-    // TODO: IMPLEMENT
-    it.skip("runs with empty string --env value", stdioWrap(function (done) {
+      run({
+        argv: ["node", "builder", "run", "echo", "--env-path=env.json"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.have.callCount(1);
+
+        readFile("stdout.log", function (data) {
+          expect(data).to.contain("string - FROM FILE");
+        }, done);
+      });
+    });
+
+    it("runs with empty string --env value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -603,7 +625,7 @@ describe("bin/builder-core", function () {
       });
 
       run({
-        argv: ["node", "builder", "run", "echo", "--env='{\"TEST_MESSAGE\":\"\"}'"]
+        argv: ["node", "builder", "run", "echo", "--env={\"TEST_MESSAGE\":\"\"}"]
       }, function (err) {
         if (err) { return done(err); }
 
@@ -613,7 +635,7 @@ describe("bin/builder-core", function () {
           expect(data).to.contain("string - EMPTY");
         }, done);
       });
-    }));
+    });
 
     // TODO: IMPLEMENT
     it("TODO: runs with empty string --env-path value");

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+/*eslint max-statements:[2,30]*/
 
 /**
  * These are _almost_ functional tests as we're basically invoking the entire
@@ -157,6 +158,13 @@ describe("bin/builder-core", function () {
       throw new Error("should have already thrown");
     });
 
+    // TODO: IMPLEMENT
+    it("errors on empty --env value");
+    it("errors on non-JSON --env value");
+    it("errors on non-Object --env value");
+    it("errors on empty --env-path value");
+    it("errors on non-JSON --env-path value");
+    it("errors on non-Object --env-path value");
   });
 
   describe("builder --version", function () {
@@ -557,8 +565,7 @@ describe("bin/builder-core", function () {
 
     });
 
-    // TODO: HERE
-    it.skip("runs with --env value", stdioWrap(function (done) {
+    it("runs with --env value", stdioWrap(function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
@@ -569,7 +576,7 @@ describe("bin/builder-core", function () {
       });
 
       run({
-        argv: ["node", "builder", "run", "echo", "--env='{\"TEST_MESSAGE\":\"HI\"}'"]
+        argv: ["node", "builder", "run", "echo", "--env={\"TEST_MESSAGE\":\"HI\"}"]
       }, function (err) {
         if (err) { return done(err); }
 
@@ -580,6 +587,9 @@ describe("bin/builder-core", function () {
         }, done);
       });
     }));
+
+    // TODO: IMPLEMENT
+    it("TODO: runs with --env-path value");
 
     // TODO: IMPLEMENT
     it.skip("runs with empty string --env value", stdioWrap(function (done) {
@@ -604,6 +614,9 @@ describe("bin/builder-core", function () {
         }, done);
       });
     }));
+
+    // TODO: IMPLEMENT
+    it("TODO: runs with empty string --env-path value");
 
     it("runs with --tries=2", function (done) {
       base.sandbox.spy(Task.prototype, "run");
@@ -1497,6 +1510,10 @@ describe("bin/builder-core", function () {
         }, done);
       });
     });
+
+    // TODO: IMPLEMENT.
+    it("TODO: runs with envs overriding --env value");
+    it("TODO: runs with envs overriding --env-path value");
 
   });
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -689,12 +689,12 @@ describe("bin/builder-core", function () {
       });
     });
 
-    it.only("runs with empty string --env value", function (done) {
+    it("runs with empty string --env value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({
           "scripts": {
-            "echo": "node test/server/fixtures/echo.js" // TODO RENABLE >> stdout.log"
+            "echo": "node test/server/fixtures/echo.js >> stdout.log"
           }
         }, null, 2)
       });
@@ -706,12 +706,10 @@ describe("bin/builder-core", function () {
 
         expect(Task.prototype.run).to.have.callCount(1);
 
-        // TODO: REVERT
-        done();
-
-        // readFile("stdout.log", function (data) {
-        //   expect(data).to.contain("string - EMPTY");
-        // }, done);
+        readFile("stdout.log", function (data) {
+          // Node v4+ w/ Windows has `undefined` vs. `string` for empty strings.
+          expect(data).to.contain("EMPTY");
+        }, done);
       });
     });
 
@@ -736,7 +734,8 @@ describe("bin/builder-core", function () {
         expect(Task.prototype.run).to.have.callCount(1);
 
         readFile("stdout.log", function (data) {
-          expect(data).to.contain("string - EMPTY");
+          // Node v4+ w/ Windows has `undefined` vs. `string` for empty strings.
+          expect(data).to.contain("EMPTY");
         }, done);
       });
     });

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -637,8 +637,31 @@ describe("bin/builder-core", function () {
       });
     });
 
-    // TODO: IMPLEMENT
-    it("TODO: runs with empty string --env-path value");
+    it("runs with empty string --env-path value", function (done) {
+      base.sandbox.spy(Task.prototype, "run");
+      base.mockFs({
+        "package.json": JSON.stringify({
+          "scripts": {
+            "echo": "node test/server/fixtures/echo.js >> stdout.log"
+          }
+        }, null, 2),
+        "env.json": JSON.stringify({
+          "TEST_MESSAGE": ""
+        }, null, 2)
+      });
+
+      run({
+        argv: ["node", "builder", "run", "echo", "--env-path=env.json"]
+      }, function (err) {
+        if (err) { return done(err); }
+
+        expect(Task.prototype.run).to.have.callCount(1);
+
+        readFile("stdout.log", function (data) {
+          expect(data).to.contain("string - EMPTY");
+        }, done);
+      });
+    });
 
     it("runs with --tries=2", function (done) {
       base.sandbox.spy(Task.prototype, "run");

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -689,7 +689,7 @@ describe("bin/builder-core", function () {
       });
     });
 
-    it("runs with empty string --env value", function (done) {
+    it.only("runs with empty string --env value", function (done) {
       base.sandbox.spy(Task.prototype, "run");
       base.mockFs({
         "package.json": JSON.stringify({

--- a/test/server/spec/lib/args.spec.js
+++ b/test/server/spec/lib/args.spec.js
@@ -26,7 +26,9 @@ describe("lib/args", function () {
         help: true,
         logLevel: "none",
         quiet: false,
-        version: false
+        version: false,
+        env: null,
+        envPath: null
       });
     });
 
@@ -40,7 +42,9 @@ describe("lib/args", function () {
         help: true,
         logLevel: "none",
         quiet: false,
-        version: false
+        version: false,
+        env: null,
+        envPath: null
       });
     });
 


### PR DESCRIPTION
* Adds `--env`, `--env-path` flags so you can add cross-OS-compatible environment variables via a JSON object.
* Updates travis ci matrix
* Abstract json parsing to utility.
* Fix indentation level of some sections. Fixes #131 

/cc @exogen 