### PR TITLE
Add npm v4 to CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,17 @@ branches:
 
 env:
   matrix:
-    - NPM_3=true
-    - NPM_3=false
+    - TEST_NPM_VERSION=2
+    - TEST_NPM_VERSION=3
+    - TEST_NPM_VERSION=4
 
 before_install:
   # GUI for real browsers.
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
-  # Potentially update to npm 3
-  - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
+  # Use the requested version of npm
+  - npm install -g "npm@$TEST_NPM_VERSION"
 
 script:
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,27 +2,52 @@
 environment:
   matrix:
     - nodejs_version: 0.10
+      TEST_NPM_VERSION: 3
+
     - nodejs_version: 0.12
+      TEST_NPM_VERSION: 3
+
     - nodejs_version: 4
+      TEST_NPM_VERSION: 3
+
     - nodejs_version: 5
+      TEST_NPM_VERSION: 3
+
     - nodejs_version: 6
+      TEST_NPM_VERSION: 3
+
+    - nodejs_version: 0.10
+      TEST_NPM_VERSION: 4
+
+    - nodejs_version: 0.12
+      TEST_NPM_VERSION: 4
+
+    - nodejs_version: 4
+      TEST_NPM_VERSION: 4
+
+    - nodejs_version: 5
+      TEST_NPM_VERSION: 4
+
+    - nodejs_version: 6
+      TEST_NPM_VERSION: 4
+
 
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # Install and use local, modern NPM
-  - npm install npm@next
+  - ps: npm install -g "npm@$env:TEST_NPM_VERSION"
   # install modules
-  - node_modules\.bin\npm install
+  - npm install
 
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
   - node --version
-  - node_modules\.bin\npm --version
+  - npm --version
   # run tests
-  - node_modules\.bin\npm run builder:check
+  - npm run builder:check
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
This adds the new npm v4 to our Travis and AppVeyor builds.

* In the Travis config, the `NPM_3` var was changed to `TEST_NPM_VERSION`.
* In the AppVeyor config, instead of always installing `npm@next`, we install 3 and 4 for each supported version of Node. I'm guessing since we were installing `npm@next` before, then npm 2.x was never part of this build. We could add it, but this PR currently just continues existing tradition.
* npm is now installed globally in the AppVeyor config. This is a more realistic setup, and it's working fine for me in my `postinstall-build` CI.

/cc @ryan-roemer 