### PR TITLE
Bug: Use actual archetype resolved paths to enhance NODE_PATH and PATH

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,9 +11,6 @@ History
 * Add extra higher level directory check when `LOCAL_DEV=true` and
   `--expand-archetype` specified.
 * Make config loading failure a simple `log.info` instead of `log.warn`.
-* Have `--expand-archetype` check for presence of local archetype _first_, then
-  move up the tree...
-  [#45](https://github.com/FormidableLabs/builder/issues/45)
 
 ## 3.1.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ History
   [#134](https://github.com/FormidableLabs/builder/issues/134)
 * Add extra higher level directory check when `LOCAL_DEV=true` and
   `--expand-archetype` specified.
+* Make config loading failure a simple `log.info` instead of `log.warn`.
 * Have `--expand-archetype` check for presence of local archetype _first_, then
   move up the tree...
   [#45](https://github.com/FormidableLabs/builder/issues/45)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,12 @@ History
 
 ## Unreleased
 
+* Add in `NODE_PATH` and `PATH` from _actual resolved paths_ of prod and dev
+  archetypes instead of guessed paths. This will better support `yarn`, which
+  flattens `node_modules/.bin` in different ways than real `npm`. It is also
+  likely more correct than before.
+* Add extra higher level directory check when `LOCAL_DEV=true` and
+  `--expand-archetype` specified.
 * Have `--expand-archetype` check for presence of local archetype _first_, then
   move up the tree...
   [#45](https://github.com/FormidableLabs/builder/issues/45)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ History
   archetypes instead of guessed paths. This will better support `yarn`, which
   flattens `node_modules/.bin` in different ways than real `npm`. It is also
   likely more correct than before.
+  [#134](https://github.com/FormidableLabs/builder/issues/134)
 * Add extra higher level directory check when `LOCAL_DEV=true` and
   `--expand-archetype` specified.
 * Have `--expand-archetype` check for presence of local archetype _first_, then

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+## Unreleased
+
+* Have `--expand-archetype` check for presence of local archetype _first_, then
+  move up the tree...
+  [#45](https://github.com/FormidableLabs/builder/issues/45)
+
 ## 3.1.0
 
 * Add `--env` environment variable flag.

--- a/bin/builder-core.js
+++ b/bin/builder-core.js
@@ -23,7 +23,7 @@ module.exports = function (opts, callback) {
   opts = (arguments.length === 2 ? opts : {}) || {};
 
   // TODO: Document extra effects of `--expand-archetype`
-  process.argv.push("--expand-archetype"); // TODO HACK REMOVE
+  //process.argv.push("--expand-archetype"); // TODO HACK REMOVE
 
   // Configuration
   var config = new Config({

--- a/bin/builder-core.js
+++ b/bin/builder-core.js
@@ -22,9 +22,6 @@ module.exports = function (opts, callback) {
   callback = arguments.length === 2 ? callback : opts;
   opts = (arguments.length === 2 ? opts : {}) || {};
 
-  // TODO: Document extra effects of `--expand-archetype`
-  //process.argv.push("--expand-archetype"); // TODO HACK REMOVE
-
   // Configuration
   var config = new Config({
     env: opts.env,

--- a/bin/builder-core.js
+++ b/bin/builder-core.js
@@ -22,8 +22,14 @@ module.exports = function (opts, callback) {
   callback = arguments.length === 2 ? callback : opts;
   opts = (arguments.length === 2 ? opts : {}) || {};
 
+  // TODO: Document extra effects of `--expand-archetype`
+  process.argv.push("--expand-archetype"); // TODO HACK REMOVE
+
   // Configuration
-  var config = new Config();
+  var config = new Config({
+    env: opts.env,
+    argv: opts.argv
+  });
 
   // Set up environment
   var env = new Environment({

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,13 +15,6 @@ var args = require("./args");
 var log = require("./log");
 var expandFlag = require("./utils/archetype").expandFlag;
 
-// TODO REMOVE
-var tempLog = function () {
-  //obj
-  // tempLog("/Users/rye/Desktop/yarn.txt",
-  //   JSON.stringify(obj); // TODO REMOVE
-};
-
 /**
  * Configuration wrapper.
  *
@@ -112,10 +105,6 @@ Config.prototype._loadArchetypePkg = function (name) {
     } catch (err) {
       /*eslint-disable no-empty*/
       // Pass through error
-      tempLog({
-        argv: process.argv,
-        err: err.toString()
-      }); // TODO REMOVE
     }
 
     // Allow a lower directory peek if expanding archetype.
@@ -126,10 +115,6 @@ Config.prototype._loadArchetypePkg = function (name) {
       } catch (err) {
         /*eslint-disable no-empty*/
         // Pass through error
-        tempLog({
-          argv: process.argv,
-          err: err.toString()
-        }); // TODO REMOVE
       }
     }
   }
@@ -199,13 +184,7 @@ Config.prototype._loadDevPkgs = function (archetypes) {
       try {
         return _.extend({ name: name }, self._loadArchetypePkg(name));
       } catch (err) {
-        /*eslint-disable no-empty*/
         // Pass through error
-        tempLog({
-          argv: process.argv,
-          err: err.toString(),
-          fn: "Config.prototype._loadDevPkgs"
-        }); // TODO REMOVE
         return null;
       }
     })
@@ -326,17 +305,9 @@ Object.defineProperties(Config.prototype, {
      * @returns {Array} Archetype bin paths
      */
     get: function () {
-      var pkgPaths = _.map([].concat(this.pkgs, this.devPkgs), function (pkg) {
+      return _.map([].concat(this.pkgs, this.devPkgs), function (pkg) {
         return path.join(pkg.path, "node_modules/.bin");
       });
-
-      tempLog({
-        argv: process.argv,
-        pkgPaths: pkgPaths,
-        fn: "archetypePaths"
-      }); // TODO REMOVE
-
-      return pkgPaths;
     }
   },
 
@@ -347,17 +318,9 @@ Object.defineProperties(Config.prototype, {
      * @returns {Array} Archetype `node_modules` paths
      */
     get: function () {
-      var pkgPaths = _.map([].concat(this.pkgs, this.devPkgs), function (pkg) {
+      return _.map([].concat(this.pkgs, this.devPkgs), function (pkg) {
         return path.join(pkg.path, "node_modules");
       });
-
-      tempLog({
-        argv: process.argv,
-        pkgPaths: pkgPaths,
-        fn: "archetypeNodePaths"
-      }); // TODO REMOVE
-
-      return pkgPaths;
     }
   },
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,20 +13,28 @@ var yaml = require("js-yaml");
 var chalk = require("chalk");
 var args = require("./args");
 var log = require("./log");
+var expandFlag = require("./utils/archetype").expandFlag;
 
 /**
  * Configuration wrapper.
  *
- * @param {Object} cfg  Configuration object or JSON/YAML file (Default: `.builderrc`)
+ * @param {Object} opts         Options object
+ * @param {Object} opts.env     Raw environment (Default `process.env`)
+ * @param {Array}  opts.argv    Raw arguments array (Default: `process.argv`)
  * @returns {void}
  */
-var Config = module.exports = function (cfg) {
+var Config = module.exports = function (opts) {
   log.info("config:environment", JSON.stringify({
     cwd: process.cwd(),
     dir: __dirname
   }));
 
-  this.cfg = this._loadConfig(cfg);
+  // Internal global state.
+  opts = opts || {};
+  this._args = args.general(opts.argv || process.argv);
+  this.expandArchetype = expandFlag(opts);
+
+  this.cfg = this._loadConfig();
   this.archetypes = this.cfg.archetypes || [];
 
   // Include the `-dev` packages.
@@ -59,32 +67,25 @@ Config.prototype._lazyRequire = function (mod) {
 /**
  * Load configuration.
  *
- * @param   {Object} cfg  Configuration object or JSON/YAML file (Default: `.builderrc`)
- * @returns {Object}      Configuration object
+ * @returns {Object} Configuration object
  */
-Config.prototype._loadConfig = function (cfg) {
-  cfg = cfg || ".builderrc";
-
+Config.prototype._loadConfig = function () {
   // Override from command line.
-  var parsed = args.general();
-  if (parsed.builderrc) {
-    cfg = parsed.builderrc;
-  }
+  var cfgObj = this._args.builderrc || ".builderrc";
+  var cfg = {};
 
   // Load from builderrc.
-  if (typeof cfg === "string") {
+  if (typeof cfgObj === "string") {
     try {
-      cfg = yaml.safeLoad(fs.readFileSync(cfg, "utf8"));
+      cfg = yaml.safeLoad(fs.readFileSync(cfgObj, "utf8"));
     } catch (err) {
-      if (err.code === "ENOENT") {
-        log.warn("config", "Unable to load config file: " + cfg);
-      } else {
+      log.info("config", "Unable to load config file: " + cfgObj);
+
+      if (err.code !== "ENOENT") {
         log.error("config", err.toString());
         throw err;
       }
     }
-
-    cfg = cfg || {};
   }
 
   return cfg;
@@ -107,6 +108,25 @@ Config.prototype._loadArchetypePkg = function (name) {
     } catch (err) {
       /*eslint-disable no-empty*/
       // Pass through error
+      fs.writeFileSync("/Users/rye/Desktop/yarn.txt", JSON.stringify({
+        argv: process.argv,
+        err: err.toString()
+      }, null, 2), { flag: "a" }); // TODO REMOVE
+    }
+
+    // Allow a lower directory peek if expanding archetype.
+    if (this.expandArchetype) {
+      try {
+        pkg = pkg || this._lazyRequire(
+          path.join(process.cwd(), "../../node_modules", name, "package.json"));
+      } catch (err) {
+        /*eslint-disable no-empty*/
+        // Pass through error
+        fs.writeFileSync("/Users/rye/Desktop/yarn.txt", JSON.stringify({
+          argv: process.argv,
+          err: err.toString()
+        }, null, 2), { flag: "a" }); // TODO REMOVE
+      }
     }
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,13 @@ var args = require("./args");
 var log = require("./log");
 var expandFlag = require("./utils/archetype").expandFlag;
 
+// TODO REMOVE
+var tempLog = function () {
+  //obj
+  // tempLog("/Users/rye/Desktop/yarn.txt",
+  //   JSON.stringify(obj); // TODO REMOVE
+};
+
 /**
  * Configuration wrapper.
  *
@@ -37,11 +44,8 @@ var Config = module.exports = function (opts) {
   this.cfg = this._loadConfig();
   this.archetypes = this.cfg.archetypes || [];
 
-  // Include the `-dev` packages.
-  this.allArchetypes = this.archetypes.reduce(function (memo, name) {
-    return memo.concat([name, name + "-dev"]);
-  }, []);
-
+  // Array of `{ name, path }`
+  this.devPkgs = this._loadDevPkgs(this.archetypes);
   // Array of `{ name, mod, path, scripts, config }`
   this.pkgs = this._loadPkgs(this.archetypes);
 };
@@ -108,10 +112,10 @@ Config.prototype._loadArchetypePkg = function (name) {
     } catch (err) {
       /*eslint-disable no-empty*/
       // Pass through error
-      fs.writeFileSync("/Users/rye/Desktop/yarn.txt", JSON.stringify({
+      tempLog({
         argv: process.argv,
         err: err.toString()
-      }, null, 2), { flag: "a" }); // TODO REMOVE
+      }); // TODO REMOVE
     }
 
     // Allow a lower directory peek if expanding archetype.
@@ -122,10 +126,10 @@ Config.prototype._loadArchetypePkg = function (name) {
       } catch (err) {
         /*eslint-disable no-empty*/
         // Pass through error
-        fs.writeFileSync("/Users/rye/Desktop/yarn.txt", JSON.stringify({
+        tempLog({
           argv: process.argv,
           err: err.toString()
-        }, null, 2), { flag: "a" }); // TODO REMOVE
+        }); // TODO REMOVE
       }
     }
   }
@@ -166,17 +170,50 @@ Config.prototype._loadPkgs = function (archetypes) {
     .value());
 
   // Add scripts, config.
-  pkgs = _.mapValues(pkgs, function (pkg) {
-    var mod = pkg.mod || {};
+  return _.chain(pkgs)
+    .mapValues(function (pkg) {
+      var mod = pkg.mod || {};
 
-    return _.extend({
-      config: mod.config,
-      scripts: pkg.name === "ROOT" ? mod.scripts || {} : self._loadArchetypeScripts(pkg)
-    }, pkg);
-  });
-
-  return pkgs;
+      return _.extend({
+        config: mod.config,
+        scripts: pkg.name === "ROOT" ? mod.scripts || {} : self._loadArchetypeScripts(pkg)
+      }, pkg);
+    })
+    .toArray()
+    .value();
 };
+
+/**
+ * Load dev packages (if available).
+ *
+ * @param   {Array} archetypes  Archetype names
+ * @returns {Array}             Array of `{ name, path }`
+ */
+Config.prototype._loadDevPkgs = function (archetypes) {
+  var self = this;
+
+  return _.chain(archetypes)
+    .map(function (baseName) {
+      var name = baseName + "-dev";
+
+      try {
+        return _.extend({ name: name }, self._loadArchetypePkg(name));
+      } catch (err) {
+        /*eslint-disable no-empty*/
+        // Pass through error
+        tempLog({
+          argv: process.argv,
+          err: err.toString(),
+          fn: "Config.prototype._loadDevPkgs"
+        }); // TODO REMOVE
+        return null;
+      }
+    })
+    .filter(_.identity)
+    .reverse()
+    .value();
+};
+
 
 /**
  * Archetype package scripts.
@@ -289,9 +326,17 @@ Object.defineProperties(Config.prototype, {
      * @returns {Array} Archetype bin paths
      */
     get: function () {
-      return _.map(this.allArchetypes, function (name) {
-        return path.join(process.cwd(), "node_modules", name, "node_modules/.bin");
+      var pkgPaths = _.map([].concat(this.pkgs, this.devPkgs), function (pkg) {
+        return path.join(pkg.path, "node_modules/.bin");
       });
+
+      tempLog({
+        argv: process.argv,
+        pkgPaths: pkgPaths,
+        fn: "archetypePaths"
+      }); // TODO REMOVE
+
+      return pkgPaths;
     }
   },
 
@@ -302,9 +347,17 @@ Object.defineProperties(Config.prototype, {
      * @returns {Array} Archetype `node_modules` paths
      */
     get: function () {
-      return _.map(this.allArchetypes, function (name) {
-        return path.join(process.cwd(), "node_modules", name, "node_modules");
+      var pkgPaths = _.map([].concat(this.pkgs, this.devPkgs), function (pkg) {
+        return path.join(pkg.path, "node_modules");
       });
+
+      tempLog({
+        argv: process.argv,
+        pkgPaths: pkgPaths,
+        fn: "archetypeNodePaths"
+      }); // TODO REMOVE
+
+      return pkgPaths;
     }
   },
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -57,8 +57,6 @@ var Environment = module.exports = function (opts) {
   this.env[ENV_PATH_NAME] = this.updatePath(this.config.archetypePaths);
   this.env.NODE_PATH = this.updateNodePath(this.config.archetypeNodePaths);
 
-  console.error("TODO HERE PATH", this.env[ENV_PATH_NAME]); // eslint-disable-line
-
   // Add in npm config environment variables.
   this.updateConfigVars(this.config.pkgConfigs);
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -57,6 +57,8 @@ var Environment = module.exports = function (opts) {
   this.env[ENV_PATH_NAME] = this.updatePath(this.config.archetypePaths);
   this.env.NODE_PATH = this.updateNodePath(this.config.archetypeNodePaths);
 
+  console.error("TODO HERE PATH", this.env[ENV_PATH_NAME]); // eslint-disable-line
+
   // Add in npm config environment variables.
   this.updateConfigVars(this.config.pkgConfigs);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -11,6 +11,7 @@ var Config = require("./config");
 var Environment = require("./environment");
 var Task = require("./task");
 var clone = require("./utils/clone");
+var expandFlag = require("./utils/archetype").expandFlag;
 var runner;
 
 // Helper for command strings for logging.
@@ -102,7 +103,7 @@ var expandArchetype = function (cmd, opts, env) {
   env = env || {};
 
   // Short-circuit if no expansion.
-  var expand = opts.expandArchetype || env._BUILDER_ARGS_EXPAND_ARCHETYPE === "true";
+  var expand = opts.expandArchetype || expandFlag({ env: env });
   if (expand !== true) {
     return cmd;
   }
@@ -288,7 +289,9 @@ var addSetup = function (setup, shOpts) {
   //
   // **Note**: Could refactor this out to a higher-level `create` method or
   // something that could be reused by `builder-core.js`
-  var config = new Config();
+  var config = new Config({
+    env: shOpts.env
+  });
   var env = new Environment({
     config: config,
     env: shOpts.env

--- a/lib/utils/archetype.js
+++ b/lib/utils/archetype.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/**
+ * Archetype utilities
+ */
+var args = require("../args");
+
+/**
+ * Return if `--expand-archetype` flag is set (or in env).
+ *
+ * @param {Object} opts         Options object
+ * @param {Object} opts.env     Raw environment (Default `process.env`)
+ * @param {Array}  opts.argv    Raw arguments array (Default: `process.argv`)
+ * @returns {void}
+ * @returns {Boolean}           True if archetype is expanded.
+ */
+module.exports.expandFlag = function (opts) {
+  opts = opts || {};
+  var env = opts.env || process.env; // Raw environment object.
+  var parsed = args.general(opts.argv || process.argv);
+
+  return parsed.expandArchetype || env._BUILDER_ARGS_EXPAND_ARCHETYPE === "true";
+};

--- a/lib/utils/archetype.js
+++ b/lib/utils/archetype.js
@@ -11,7 +11,6 @@ var args = require("../args");
  * @param {Object} opts         Options object
  * @param {Object} opts.env     Raw environment (Default `process.env`)
  * @param {Array}  opts.argv    Raw arguments array (Default: `process.argv`)
- * @returns {void}
  * @returns {Boolean}           True if archetype is expanded.
  */
 module.exports.expandFlag = function (opts) {


### PR DESCRIPTION
* Add in `NODE_PATH` and `PATH` from _actual resolved paths_ of prod and dev archetypes instead of guessed paths. This will better support `yarn`, which flattens `node_modules/.bin` in different ways than real `npm`. It is also likely more correct than before. Fixes #134
* Add extra higher level directory check when `LOCAL_DEV=true` and `--expand-archetype` specified.
* Make config loading failure a simple `log.info` instead of `log.warn`.

/cc @exogen @kenwheeler @paulathevalley 