### PR TITLE
Builder cannot resolve shared dependencies

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -27,7 +27,7 @@ var uniqueVals = function (val, i, vals) { return vals.indexOf(val) === i; };
 
 // Node directories.
 var CWD_NODE_PATHS = findNodeModules({ cwd: process.cwd(), relative: false });
-var CWD_BINS = CWD_NODE_PATHS.map(p => path.join(p, '.bin'));
+var CWD_BINS = CWD_NODE_PATHS.map(function (p) { return path.join(p, ".bin"); });
 
 /**
  * Environment wrapper.

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -8,6 +8,7 @@
  */
 var _ = require("lodash");
 var path = require("path");
+var findNodeModules = require("find-node-modules");
 var args = require("./args");
 var clone = require("./utils/clone");
 var jsonParse = require("./utils/json").parse;
@@ -25,8 +26,8 @@ var splitPath = function (val) {
 var uniqueVals = function (val, i, vals) { return vals.indexOf(val) === i; };
 
 // Node directories.
-var CWD_BIN = path.join(process.cwd(), "node_modules/.bin");
-var CWD_NODE_PATH = path.join(process.cwd(), "node_modules");
+var CWD_NODE_PATHS = findNodeModules({ cwd: process.cwd(), relative: false });
+var CWD_BINS = CWD_NODE_PATHS.map(p => path.join(p, '.bin'));
 
 /**
  * Environment wrapper.
@@ -85,7 +86,7 @@ var Environment = module.exports = function (opts) {
 Environment.prototype.updatePath = function (archetypePaths) {
   return []
     .concat(archetypePaths || [])
-    .concat([CWD_BIN])
+    .concat(CWD_BINS || [])
     .concat(splitPath(this.env[ENV_PATH_NAME]))
     .concat(splitPath(this.env.PATH))
     .filter(uniqueVals)
@@ -107,7 +108,7 @@ Environment.prototype.updatePath = function (archetypePaths) {
 Environment.prototype.updateNodePath = function (archetypeNodePaths) {
   return []
     .concat(archetypeNodePaths || [])
-    .concat([CWD_NODE_PATH])
+    .concat(CWD_NODE_PATHS || [])
     .concat(splitPath(this.env.NODE_PATH))
     .filter(uniqueVals)
     .join(DELIM);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "chalk": "^1.1.1",
+    "find-node-modules": "^1.0.4",
     "js-yaml": "^3.4.3",
     "lodash": "^3.10.1",
     "nopt": "^3.0.6",


### PR DESCRIPTION
Perhaps this is against the general philosophy of builder but it would be nice if builder could resolve "shared" dependencies by adding any local "node_modules" folders to its path.

For example, builder will not run commands in a monorepo that uses the [lerna hoist feature](https://github.com/lerna/lerna/blob/master/doc/hoist.md) because it doesn't know about the monorepo's base "node_modules".