### PR TITLE
Add a hint about use with monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Builder
 =======
 
 Builder takes your `npm` tasks and makes them composable, controllable from
-a single point, and flexible.
+a single point, and flexible. This is great for "monorepos".
 
 `npm` is fantastic for controlling tasks (via `scripts`) and general project
 workflows. But a project-specific `package.json` simply doesn't scale when


### PR DESCRIPTION
The README lacks a mention of the keyword "monorepo". The word "sub projects" could be good too.

FWIW, I found all of these projects before finally stumbling on Builder:

- github.com/Aldlevine/comptroller
- github.com/lerna/lerna
- github.com/boltpkg/bolt
- github.com/guigrpa/oao
- github.com/Microsoft/web-build-tools/blob/master/apps/rush
- github.com/northbrookjs/northbrook
- github.com/studio-b12/monopod
- github.com/sompylasar/zmey-gorynych
- github.com/asini/asini
- github.com/sencha/mondorepo
- github.com/signavio/binge
- github.com/jdiamond/monotool
- npmjs.com/package/redhot

Using some keywords like "monorepo", "subprojects", "multi-package repositories" would help make Builder more visible.

---

I'm actually still wondering how I will use this for a monorepo, but I bet the result will be nice.

I'm thinking that maybe I can setup each project as a separate repo, have them as git submodules in the main repo, and use another tool like [bolt](http://github.com/boltpkg/bolt) to run the command in each submodule. I'm not sure if that'll be a maintenance hassle though (submodules).

Any recommendations on the monorepo approach?