### PR TITLE
[MAJOR] Chore: Debug log level, default to quiet

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,10 +3,12 @@ History
 
 ## Unreleased MAJOR
 
+* **Breaking**: Default to `--log-leve=error` intead of `info`.
 * **Breaking**: Add `pre|post` lifecycle commands.
   [#68](https://github.com/FormidableLabs/builder/issues/68)
 * **Breaking**: Error out on invalid or conflicting command line flags passed
   to `builder`.
+* Add `--log-leve=debug`. Switch some existing logs over.
 * Add more explicit behavior and tests for `--setup` flag.
 
 ## 3.2.3

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Flags:
 * `--tries`: Number of times to attempt a task (default: `1`)
 * `--setup`: Single task to run for the entirety of `<action>`
 * `--quiet`: Silence logging
-* `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
+* `--log-level`: Level to log at (`debug`, `info`, `warn`, `error`, `none`) (default: `error`)
 * `--env`: JSON object of keys to add to environment.
 * `--env-path`: JSON file path of keys to add to environment.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
@@ -311,7 +311,7 @@ Flags:
 * `--[no-]buffer`: Buffer output until process end (default: `false`)
 * `--[no-]bail`: End all processes after the first failure (default: `true`)
 * `--quiet`: Silence logging
-* `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
+* `--log-level`: Level to log at (`debug`, `info`, `warn`, `error`, `none`) (default: `error`)
 * `--env`: JSON object of keys to add to environment.
 * `--env-path`: JSON file path of keys to add to environment.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)
@@ -368,7 +368,7 @@ Flags:
 * `--[no-]bail`: End all processes after the first failure (default: `true`)
 * `--envs-path`: Path to JSON env variable array file (default: `null`)
 * `--quiet`: Silence logging
-* `--log-level`: Level to log at (`info`, `warn`, `error`, `none`)
+* `--log-level`: Level to log at (`debug`, `info`, `warn`, `error`, `none`) (default: `error`)
 * `--env`: JSON object of keys to add to environment.
 * `--env-path`: JSON file path of keys to add to environment.
 * `--expand-archetype`: Expand `node_modules/<archetype>` with full path (default: `false`)

--- a/lib/args.js
+++ b/lib/args.js
@@ -69,9 +69,9 @@ var FLAGS = {
       default: false
     },
     "log-level": {
-      desc: "Level to log at (`info`, `warn`, `error`, `none`)",
+      desc: "Level to log at (`debug`, `info`, `warn`, `error`, `none`)",
       types: [String],
-      default: "info"
+      default: "error"
     },
     env: {
       desc: "JSON string of environment variables to add to process",

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,7 @@ var expandFlag = require("./utils/archetype").expandFlag;
  * @returns {void}
  */
 var Config = module.exports = function (opts) {
-  log.info("config:environment", JSON.stringify({
+  log.debug("config:environment", JSON.stringify({
     cwd: process.cwd(),
     dir: __dirname
   }));
@@ -122,7 +122,7 @@ Config.prototype._loadArchetypePkg = function (name) {
   try {
     pkg = pkg || this._lazyRequire(name + "/package.json");
   } catch (err) {
-    log.error("config:load-archetype-scripts",
+    log.info("config:load-archetype-scripts",
       "Error loading package.json for: " + chalk.gray(name) + " " +
       (err.message || err.toString()));
     throw err;

--- a/lib/log.js
+++ b/lib/log.js
@@ -101,6 +101,10 @@ var log = module.exports = {
       return;
     }
 
+    // Switch to `console.log` friendly methods.
+    // - `console.debug` won't normally output to stdout.
+    level = level === "debug" ? "log" : level;
+
     // Call directly once level is set.
     // This is also used to drain the queue.
     var formattedMsg = [chalk[color](wrapType(type)), msg].join(" ");

--- a/lib/log.js
+++ b/lib/log.js
@@ -10,13 +10,12 @@ var wrapType = function (type) {
 };
 
 // Levels
-// TODO: Add `debug` level and refactor to support that.
-// https://github.com/FormidableLabs/builder/issues/160
 var LEVELS = {
-  info: 0,
-  warn: 1,
-  error: 2,
-  none: 3
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  none: 4
 };
 
 /**
@@ -110,6 +109,7 @@ var log = module.exports = {
 };
 
 // Actual implementation methods.
+log.debug = log._wrapper.bind(log, "debug", "gray");
 log.info = log._wrapper.bind(log, "info", "green");
 log.warn = log._wrapper.bind(log, "warn", "yellow");
 log.error = log._wrapper.bind(log, "error", "red");

--- a/lib/task.js
+++ b/lib/task.js
@@ -436,7 +436,7 @@ Task.prototype.concurrent = function (callback) {
     return opts.setup ? self.setup(opts.setup, shOpts, callback) : null;
   });
 
-  log.info("concurrent", "Starting with queue size: " + chalk.magenta(queue || "unlimited"));
+  log.debug("concurrent", "Starting with queue size: " + chalk.magenta(queue || "unlimited"));
   async.mapLimit(paramsList, queue || Infinity, function (params, concCb) {
     // Task execution sequence
     async.series([
@@ -542,7 +542,7 @@ Task.prototype.envs = function (callback) {
       var taskEnvs = clone(envsList);
       var queue = opts.queue;
 
-      log.info("envs", "Starting with queue size: " + chalk.magenta(queue || "unlimited"));
+      log.debug("envs", "Starting with queue size: " + chalk.magenta(queue || "unlimited"));
       async.mapLimit(taskEnvs, queue || Infinity, function (taskEnv, envCb) {
         // Add each specific set of environment variables.
         // Clone `shOpts` to turn `env` into a plain object: in Node 4+

--- a/lib/utils/runner.js
+++ b/lib/utils/runner.js
@@ -184,10 +184,10 @@ module.exports.run = function (cmd, shOpts, opts, callback) {
   // Mutate env and return new command w/ file paths from the archetype itself.
   cmd = expandArchetype(cmd, opts, shOpts.env);
 
-  log.info("proc:start", cmdStr(cmd, opts));
+  log.debug("proc:start", cmdStr(cmd, opts));
   var proc = spawn(sh, [shFlag, cmd], shOpts, function (err) {
     var code = err ? err.code || 1 : 0;
-    var level = code === 0 ? "info" : "warn";
+    var level = code === 0 ? "debug" : "warn";
 
     // Output buffered output.
     if (buffer) {

--- a/lib/utils/setup.js
+++ b/lib/utils/setup.js
@@ -20,7 +20,7 @@ var runner = require("./runner");
  */
 module.exports.create = function (taskName, shOpts) {
   if (!taskName) { return null; }
-  log.info("setup:start", "Starting setup task: " + taskName);
+  log.debug("setup:start", "Starting setup task: " + taskName);
 
   // Create a `Task` object to just infer the _command_ we need.
   //

--- a/test/func/spec/func.spec.js
+++ b/test/func/spec/func.spec.js
@@ -33,7 +33,7 @@ describe("functional", function () {
   describe("environment variables", function () {
 
     it("get environment from package.json:config", function (done) {
-      exec("node \"" + builder + "\" run echo", function (err, stdout, stderr) {
+      exec("node \"" + builder + "\" run echo --log=debug", function (err, stdout, stderr) {
         if (err) { return done(err); }
 
         expect(stdout)
@@ -103,9 +103,9 @@ describe("functional", function () {
         });
     });
 
-    it("runs setup with --log-level=info flag applied", function (done) {
+    it("runs setup with --log-level=debug flag applied", function (done) {
       return exec(
-        "node \"" + builder + "\" run sleep --log-level=info --setup=echo-forever:builder",
+        "node \"" + builder + "\" run sleep --log-level=debug --setup=echo-forever:builder",
         function (err, stdout, stderr) {
           if (err) { return done(err); }
 

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -101,6 +101,7 @@ describe("bin/builder-core", function () {
 
   beforeEach(function () {
     logStubs = {
+      debug: base.sandbox.spy(),
       info: base.sandbox.spy(),
       warn: base.sandbox.spy(),
       error: base.sandbox.spy()
@@ -444,6 +445,7 @@ describe("bin/builder-core", function () {
         if (err) { return done(err); }
 
         expect(Task.prototype.run).to.be.calledOnce;
+        expect(logStubs.debug).not.be.called;
         expect(logStubs.info).not.be.called;
         expect(logStubs.warn).not.be.called;
         expect(logStubs.error).not.be.called;
@@ -472,6 +474,7 @@ describe("bin/builder-core", function () {
           .that.contains("BAD_COMMAND");
 
         expect(Task.prototype.run).to.be.calledOnce;
+        expect(logStubs.debug).not.be.called;
         expect(logStubs.info).not.be.called;
         expect(logStubs.warn).not.be.called;
         expect(logStubs.error)
@@ -883,7 +886,7 @@ describe("bin/builder-core", function () {
       });
 
       run({
-        argv: ["node", "builder", "run", "foo", "--tries=2"]
+        argv: ["node", "builder", "run", "foo", "--tries=2", "--log-level=warn"]
       }, function (err) {
         expect(err).to.have.property("message")
           .that.contains("Command failed").and
@@ -1468,6 +1471,7 @@ describe("bin/builder-core", function () {
           if (err) { return done(err); }
 
           expect(Task.prototype.run).to.be.calledOnce;
+          expect(logStubs.debug).not.be.called;
           expect(logStubs.info).not.be.called;
           expect(logStubs.warn).not.be.called;
           expect(logStubs.error).not.be.called;
@@ -1501,6 +1505,7 @@ describe("bin/builder-core", function () {
             .that.contains("BAD_COMMAND");
 
           expect(Task.prototype.run).to.be.calledOnce;
+          expect(logStubs.debug).not.be.called;
           expect(logStubs.info).not.be.called;
           expect(logStubs.warn).not.be.called;
           expect(logStubs.error)
@@ -1761,7 +1766,7 @@ describe("bin/builder-core", function () {
         argv: [
           "node", "builder", "concurrent",
           "one", "two", "three",
-          "--setup=setup", "--queue=2", "--buffer"
+          "--setup=setup", "--queue=2", "--buffer", "--log-level=info"
         ]
       }, function (err) {
         if (err) { return done(err); }

--- a/test/server/spec/bin/builder-core.spec.js
+++ b/test/server/spec/bin/builder-core.spec.js
@@ -100,8 +100,10 @@ describe("bin/builder-core", function () {
   var logStubs;
 
   beforeEach(function () {
+    var debugSpy = base.sandbox.spy();
     logStubs = {
-      debug: base.sandbox.spy(),
+      log: debugSpy,    // used for debug
+      debug: debugSpy,
       info: base.sandbox.spy(),
       warn: base.sandbox.spy(),
       error: base.sandbox.spy()
@@ -1766,14 +1768,14 @@ describe("bin/builder-core", function () {
         argv: [
           "node", "builder", "concurrent",
           "one", "two", "three",
-          "--setup=setup", "--queue=2", "--buffer", "--log-level=info"
+          "--setup=setup", "--queue=2", "--buffer", "--log-level=debug"
         ]
       }, function (err) {
         if (err) { return done(err); }
 
         // Only one setup task runs.
         // Verify through logs.
-        var setupTaskStarts = logStubs.info.args.filter(function (arg) {
+        var setupTaskStarts = logStubs.debug.args.filter(function (arg) {
           return (arg[0] || "").indexOf("Starting setup task") > -1;
         });
         expect(setupTaskStarts).to.have.length(1);


### PR DESCRIPTION
- Add `debug` log level. Fixes #160 
- Refactor existing messages to have some be `default` instead of `info`
- **Breaking**: Default to `--log-level=none` in CLI